### PR TITLE
Universal flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  
+
 <img src="/logo.png" />
 <br />
 <a href="https://goreportcard.com/report/github.com/integrii/flaggy"><img src="https://goreportcard.com/badge/github.com/integrii/flaggy"></a>
@@ -17,6 +17,7 @@ Open an issue if you hate something, or better yet, fix it and make a pull reque
 # Key Features
 
 - Very easy to use ([see examples below](https://github.com/integrii/flaggy#super-simple-example))
+- 35 different flag types supported
 - Any flag can be at at any position
 - Pretty and readable help output by default
 - Positional subcommands
@@ -33,6 +34,7 @@ Open an issue if you hate something, or better yet, fix it and make a pull reque
 - Flags can use a single dash or double dash (`--flag`, `-flag`, `-f`, `--f`)
 - Flags can have `=` assignment operators, or use a space (`--flag=value`, `--flag value`)
 - Flags support single quote globs with spaces (`--flag 'this is all one value'`)
+- Flags of slice types can be passed multiple times (`-f one -f two -f three`)
 - Optional but default version output with `-v` or `--version`
 - Optional but default help output with `-h` or `--help`
 - Optional but default show help when any invalid or unknown parameter is passed

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-![flaggy logo](/logo.png)
-
+<center>![flaggy logo](/logo.png)
+<br>
 [![flaggy go report](https://goreportcard.com/badge/github.com/integrii/flaggy)](https://goreportcard.com/report/github.com/integrii/flaggy) [![Build Status](https://travis-ci.org/integrii/flaggy.svg?branch=master)](https://travis-ci.org/integrii/flaggy) [![godoc](https://camo.githubusercontent.com/d48cccd1ce67ddf8ba7fc356ec1087f3f7aa6d12/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f6c696c65696f2f6c696c653f7374617475732e737667)](http://godoc.org/github.com/integrii/flaggy) [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)
-
-
-
+</center>
+<br />
+<br />
 Sensible command-line flag parsing with support for subcommands and positional values. Flags can be at any position.  No required project or package layout like [Cobra](https://github.com/spf13/Cobra), and **no third party package dependencies**.  
 
 Check out the [godoc](http://godoc.org/github.com/integrii/flaggy), [examples directory](https://github.com/integrii/flaggy/tree/master/examples), and [examples in this readme](https://github.com/integrii/flaggy#super-simple-example) to get started quickly.

--- a/README.md
+++ b/README.md
@@ -37,24 +37,70 @@ Open an issue if you hate something, or better yet, fix it and make a pull reque
 # Example Help Output
 
 ```
-testCommand - Description goes here.  Get more information at http://my.website
-This is an optional prepend for help output
+testCommand - Description goes here.  Get more information at our website.
+This is a prepend for help
+
+  Usage:
+    testCommand [subcommandA|subcommandB|subcommandC] [testPositionalA] [testPositionalB]
 
   Positional Variables:
-    testPositionalA (Position 2) (Required) Test positional A does some things with a positional value.
+    testPositionalA (Position 2) (Required) - Test positional A does some things with a positional value.
+    testPositionalB (Position 3) - Test positional B does some less than serious things with a positional value.
 
-  Subommands:
-    subcommandA (a) (Position 1) Subcommand A is a command that does stuff
-    subcommandB (b) (Position 1) Subcommand B is a command that does other stuff
-    subcommandC (c) (Position 1) Subcommand C is a command that does SERIOUS stuff
+  Subcommands:
+    subcommandA (a) - Subcommand A is a command that does stuff
+    subcommandB (b) - Subcommand B is a command that does other stuff
+    subcommandC (c) - Subcommand C is a command that does SERIOUS stuff
 
- Flags:
-    --stringFlag (-s) This is a test string flag that does some stringy string stuff.
-    --intFlg (-i) This is a test int flag that does some interesting int stuff.
-    --boolFlag (-b) This is a test bool flag that does some booly bool stuff.
+  Flags:
+    -s --stringFlag  This is a test string flag that does some stringy string stuff.
+    -i --intFlg  This is a test int flag that does some interesting int stuff.
+    -b --boolFlag  This is a test bool flag that does some booly bool stuff.
+    -d --durationFlag  This is a test duration flag that does some untimely stuff.
 
-This is an optional append for help
+This is an optional append message for help
 This is an optional help add-on message
+```
+
+# Supported Flag Types:
+
+```
+string
+[]string
+bool
+[]bool
+time.Duration
+[]time.Duration
+float32
+[]float32
+float64
+[]float64
+uint
+uint64
+[]uint64
+uint32
+[]uint32
+uint16
+[]uint16
+uint8
+[]uint8
+[]byte
+int
+[]int
+int64
+[]int64
+int32
+[]int32
+int16
+[]int16
+int8
+[]int8
+net.IP
+[]net.IP
+net.HardwareAddr
+[]net.HardwareAddr
+net.IPMask
+[]net.IPMask
 ```
 
 

--- a/argumentParser.go
+++ b/argumentParser.go
@@ -4,18 +4,19 @@ package flaggy
 // specified parsers (which normally include a Parser and Subcommand).
 // The return values represent the key being set, and any errors
 // returned when setting the key, such as failures to conver the string
-// into the appropriate flag value.
+// into the appropriate flag value.  We stop assigning values as soon
+// as we find a parser that accepts it.
 func setValueForParsers(key string, value string, parsers ...ArgumentParser) (bool, error) {
 
 	var valueWasSet bool
 
 	for _, p := range parsers {
-		valueWasSetKey, err := p.SetValueForKey(key, value)
+		valueWasSet, err := p.SetValueForKey(key, value)
 		if err != nil {
 			return valueWasSet, err
 		}
-		if valueWasSetKey {
-			valueWasSet = true
+		if valueWasSet {
+			break
 		}
 	}
 

--- a/flag.go
+++ b/flag.go
@@ -282,6 +282,14 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		existing := f.AssignmentVar.(*[]net.HardwareAddr)
 		new := append(*existing, v)
 		f.AssignmentVar = &new
+	case *net.IPMask:
+		v := net.IPMask(net.ParseIP(value).To4())
+		f.AssignmentVar = &v
+	case *[]net.IPMask:
+		v := net.IPMask(net.ParseIP(value).To4())
+		existing := f.AssignmentVar.(*[]net.IPMask)
+		new := append(*existing, v)
+		f.AssignmentVar = &new
 	default:
 		return errors.New("Unknown flag assignmentVar supplied in flag " + f.LongName + " " + f.ShortName)
 	}

--- a/flag.go
+++ b/flag.go
@@ -6,12 +6,16 @@ import (
 	"time"
 )
 
+// FlagType represents the type a flag is backed with
+type FlagType int
+
 // Flag holds the base methods for all flag types
 type Flag struct {
-	ShortName   string
-	LongName    string
-	Description string
-	Hidden      bool // indicates this flag should be hidden from help and suggestions
+	ShortName     string
+	LongName      string
+	Description   string
+	Hidden        bool         // indicates this flag should be hidden from help and suggestions
+	AssignmentVar *interface{} // TODO - implement as type switch where specific types required.  Issue #7
 }
 
 // HasName indicates that this flag's short or long name matches the
@@ -123,12 +127,7 @@ func parseFlagToName(arg string) string {
 // flagIsBool determines if the flag is a bool within the specified parser
 // and subcommand's context
 func flagIsBool(sc *Subcommand, p *Parser, key string) bool {
-	for _, f := range sc.BoolFlags {
-		if f.HasName(key) {
-			return true
-		}
-	}
-	for _, f := range p.BoolFlags {
+	for _, f := range sc.Flags {
 		if f.HasName(key) {
 			return true
 		}

--- a/flag.go
+++ b/flag.go
@@ -34,7 +34,8 @@ func (f *Flag) HasName(name string) bool {
 // the value is a type that needs parsing, that is performed as well.
 func (f *Flag) identifyAndAssignValue(value string) error {
 
-	// reflect.TypeOf(value)
+	fmt.Println("attempting to assign value", value, "to flag", f.LongName)
+
 	var err error
 
 	// depending on the type of the assignment variable, we convert the
@@ -42,9 +43,9 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 	// in flagy.  No returning vars by value.
 	switch f.AssignmentVar.(type) {
 	case *string:
-		fmt.Println("pre", f.AssignmentVar)
 		f.AssignmentVar = &value
 		fmt.Println("after", f.AssignmentVar)
+		fmt.Println("twice")
 	case *[]string:
 		v := f.AssignmentVar.(*[]string)
 		a := append(*v, value)

--- a/flag.go
+++ b/flag.go
@@ -42,7 +42,9 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 	// in flagy.  No returning vars by value.
 	switch f.AssignmentVar.(type) {
 	case *string:
+		fmt.Println("pre", f.AssignmentVar)
 		f.AssignmentVar = &value
+		fmt.Println("after", f.AssignmentVar)
 	case *[]string:
 		v := f.AssignmentVar.(*[]string)
 		a := append(*v, value)
@@ -373,7 +375,11 @@ func parseFlagToName(arg string) string {
 func flagIsBool(sc *Subcommand, p *Parser, key string) bool {
 	for _, f := range sc.Flags {
 		if f.HasName(key) {
-			return true
+			_, isBool := f.AssignmentVar.(*bool)
+			_, isBoolSlice := f.AssignmentVar.(*[]bool)
+			if isBool || isBoolSlice {
+				return true
+			}
 		}
 	}
 

--- a/flag.go
+++ b/flag.go
@@ -1,7 +1,6 @@
 package flaggy
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -43,17 +42,19 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 	// in flagy.  No returning vars by value.
 	switch f.AssignmentVar.(type) {
 	case *string:
-		f.AssignmentVar = &value
+		v, _ := (f.AssignmentVar).(*string)
+		*v = value
 	case *[]string:
 		v := f.AssignmentVar.(*[]string)
-		a := append(*v, value)
-		f.AssignmentVar = &a
+		new := append(*v, value)
+		*v = new
 	case *bool:
 		v, err := strconv.ParseBool(value)
 		if err != nil {
 			return err
 		}
-		f.AssignmentVar = &v
+		a, _ := (f.AssignmentVar).(*bool)
+		*a = v
 	case *[]bool:
 		// parse the incoming bool
 		b, err := strconv.ParseBool(value)
@@ -65,13 +66,15 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		// deref the assignment var and append to it
 		v := append(*existing, b)
 		// pointer the new value and assign it
-		f.AssignmentVar = &v
+		a, _ := (f.AssignmentVar).(*[]bool)
+		*a = v
 	case *time.Duration:
 		v, err := time.ParseDuration(value)
 		if err != nil {
 			return err
 		}
-		f.AssignmentVar = &v
+		a, _ := (f.AssignmentVar).(*time.Duration)
+		*a = v
 	case *[]time.Duration:
 		t, err := time.ParseDuration(value)
 		if err != nil {
@@ -81,29 +84,32 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		// deref the assignment var and append to it
 		v := append(*existing, t)
 		// pointer the new value and assign it
-		f.AssignmentVar = &v
+		a, _ := (f.AssignmentVar).(*[]time.Duration)
+		*a = v
 	case *float32:
 		v, err := strconv.ParseFloat(value, 32)
 		if err != nil {
 			return err
 		}
 		float := float32(v)
-		f.AssignmentVar = &float
+		a, _ := (f.AssignmentVar).(*float32)
+		*a = float
 	case *[]float32:
 		v, err := strconv.ParseFloat(value, 32)
 		if err != nil {
 			return err
 		}
-		existing := f.AssignmentVar.(*[]float32)
 		float := float32(v)
+		existing := f.AssignmentVar.(*[]float32)
 		new := append(*existing, float)
-		f.AssignmentVar = &new
+		*existing = new
 	case *float64:
 		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return err
 		}
-		f.AssignmentVar = &v
+		a, _ := (f.AssignmentVar).(*float64)
+		*a = v
 	case *[]float64:
 		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {
@@ -111,13 +117,15 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existing := f.AssignmentVar.(*[]float64)
 		new := append(*existing, v)
-		f.AssignmentVar = &new
+
+		*existing = new
 	case *int:
 		v, err := strconv.Atoi(value)
 		if err != nil {
 			return err
 		}
-		f.AssignmentVar = &v
+		e := f.AssignmentVar.(*int)
+		*e = v
 	case *[]int:
 		v, err := strconv.Atoi(value)
 		if err != nil {
@@ -125,14 +133,14 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existing := f.AssignmentVar.(*[]int)
 		new := append(*existing, v)
-		f.AssignmentVar = &new
+		*existing = new
 	case *uint:
 		v, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
 			return err
 		}
-		val := uint(v)
-		f.AssignmentVar = &val
+		existing := f.AssignmentVar.(*uint)
+		*existing = uint(v)
 	case *[]uint:
 		v, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
@@ -140,13 +148,14 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existing := f.AssignmentVar.(*[]uint)
 		new := append(*existing, uint(v))
-		f.AssignmentVar = &new
+		*existing = new
 	case *uint64:
 		v, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
 			return err
 		}
-		f.AssignmentVar = &v
+		existing := f.AssignmentVar.(*uint64)
+		*existing = v
 	case *[]uint64:
 		v, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
@@ -154,14 +163,14 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existing := f.AssignmentVar.(*[]uint64)
 		new := append(*existing, v)
-		f.AssignmentVar = &new
+		*existing = new
 	case *uint32:
 		v, err := strconv.ParseUint(value, 10, 32)
 		if err != nil {
 			return err
 		}
-		val := uint32(v)
-		f.AssignmentVar = &val
+		existing := f.AssignmentVar.(*uint32)
+		*existing = uint32(v)
 	case *[]uint32:
 		v, err := strconv.ParseUint(value, 10, 32)
 		if err != nil {
@@ -169,14 +178,15 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existing := f.AssignmentVar.(*[]uint32)
 		new := append(*existing, uint32(v))
-		f.AssignmentVar = &new
+		*existing = new
 	case *uint16:
 		v, err := strconv.ParseUint(value, 10, 16)
 		if err != nil {
 			return err
 		}
 		val := uint16(v)
-		f.AssignmentVar = &val
+		existing := f.AssignmentVar.(*uint16)
+		*existing = val
 	case *[]uint16:
 		v, err := strconv.ParseUint(value, 10, 16)
 		if err != nil {
@@ -184,29 +194,33 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existing := f.AssignmentVar.(*[]uint16)
 		new := append(*existing, uint16(v))
-		f.AssignmentVar = &new
+		*existing = new
 	case *uint8:
 		v, err := strconv.ParseUint(value, 10, 8)
 		if err != nil {
 			return err
 		}
 		val := uint8(v)
-		f.AssignmentVar = &val
+		existing := f.AssignmentVar.(*uint8)
+		*existing = val
 	case *[]uint8:
-		// parse a hex string to a slice of bytes
-		src := []byte(value)
-		dst := make([]byte, hex.DecodedLen(len(src)))
-		_, err := hex.Decode(dst, src)
+		var newSlice []uint8
+
+		v, err := strconv.ParseUint(value, 10, 8)
 		if err != nil {
 			return err
 		}
-		f.AssignmentVar = &dst
+		newV := uint8(v)
+		existing := f.AssignmentVar.(*[]uint8)
+		newSlice = append(*existing, newV)
+		*existing = newSlice
 	case *int64:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return err
 		}
-		f.AssignmentVar = &v
+		existing := f.AssignmentVar.(*int64)
+		*existing = v
 	case *[]int64:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
@@ -214,14 +228,15 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existingSlice := f.AssignmentVar.(*[]int64)
 		newSlice := append(*existingSlice, v)
-		f.AssignmentVar = &newSlice
+		*existingSlice = newSlice
 	case *int32:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return err
 		}
 		converted := int32(v)
-		f.AssignmentVar = &converted
+		existing := f.AssignmentVar.(*int32)
+		*existing = converted
 	case *[]int32:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
@@ -229,14 +244,15 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existingSlice := f.AssignmentVar.(*[]int32)
 		newSlice := append(*existingSlice, int32(v))
-		f.AssignmentVar = &newSlice
+		*existingSlice = newSlice
 	case *int16:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return err
 		}
 		converted := int16(v)
-		f.AssignmentVar = &converted
+		existing := f.AssignmentVar.(*int16)
+		*existing = converted
 	case *[]int16:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
@@ -244,14 +260,15 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existingSlice := f.AssignmentVar.(*[]int16)
 		newSlice := append(*existingSlice, int16(v))
-		f.AssignmentVar = &newSlice
+		*existingSlice = newSlice
 	case *int8:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return err
 		}
 		converted := int8(v)
-		f.AssignmentVar = &converted
+		existing := f.AssignmentVar.(*int8)
+		*existing = converted
 	case *[]int8:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
@@ -259,21 +276,23 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existingSlice := f.AssignmentVar.(*[]int8)
 		newSlice := append(*existingSlice, int8(v))
-		f.AssignmentVar = &newSlice
+		*existingSlice = newSlice
 	case *net.IP:
 		v := net.ParseIP(value)
-		f.AssignmentVar = &v
+		existing := f.AssignmentVar.(*net.IP)
+		*existing = v
 	case *[]net.IP:
 		v := net.ParseIP(value)
 		existing := f.AssignmentVar.(*[]net.IP)
 		new := append(*existing, v)
-		f.AssignmentVar = &new
+		*existing = new
 	case *net.HardwareAddr:
 		v, err := net.ParseMAC(value)
 		if err != nil {
 			return err
 		}
-		f.AssignmentVar = &v
+		existing := f.AssignmentVar.(*net.HardwareAddr)
+		*existing = v
 	case *[]net.HardwareAddr:
 		v, err := net.ParseMAC(value)
 		if err != nil {
@@ -281,15 +300,16 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		existing := f.AssignmentVar.(*[]net.HardwareAddr)
 		new := append(*existing, v)
-		f.AssignmentVar = &new
+		*existing = new
 	case *net.IPMask:
 		v := net.IPMask(net.ParseIP(value).To4())
-		f.AssignmentVar = &v
+		existing := f.AssignmentVar.(*net.IPMask)
+		*existing = v
 	case *[]net.IPMask:
 		v := net.IPMask(net.ParseIP(value).To4())
 		existing := f.AssignmentVar.(*[]net.IPMask)
 		new := append(*existing, v)
-		f.AssignmentVar = &new
+		*existing = new
 	default:
 		return errors.New("Unknown flag assignmentVar supplied in flag " + f.LongName + " " + f.ShortName)
 	}

--- a/flag.go
+++ b/flag.go
@@ -65,15 +65,6 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		v := append(*existing, b)
 		// pointer the new value and assign it
 		f.AssignmentVar = &v
-	case *[]byte:
-		// parse a hex string to a slice of bytes
-		src := []byte(value)
-		dst := make([]byte, hex.DecodedLen(len(src)))
-		_, err := hex.Decode(dst, src)
-		if err != nil {
-			return err
-		}
-		f.AssignmentVar = &dst
 	case *time.Duration:
 		v, err := time.ParseDuration(value)
 		if err != nil {
@@ -200,7 +191,15 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 		}
 		val := uint8(v)
 		f.AssignmentVar = &val
-	// []*uint8 is the same as *[]byte above
+	case *[]uint8:
+		// parse a hex string to a slice of bytes
+		src := []byte(value)
+		dst := make([]byte, hex.DecodedLen(len(src)))
+		_, err := hex.Decode(dst, src)
+		if err != nil {
+			return err
+		}
+		f.AssignmentVar = &dst
 	case *int64:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {

--- a/flag.go
+++ b/flag.go
@@ -44,8 +44,6 @@ func (f *Flag) identifyAndAssignValue(value string) error {
 	switch f.AssignmentVar.(type) {
 	case *string:
 		f.AssignmentVar = &value
-		fmt.Println("after", f.AssignmentVar)
-		fmt.Println("twice")
 	case *[]string:
 		v := f.AssignmentVar.(*[]string)
 		a := append(*v, value)

--- a/flag_test.go
+++ b/flag_test.go
@@ -73,6 +73,7 @@ func TestDetermineArgType(t *testing.T) {
 
 // TestInputParsing tests all flag types.
 func TestInputParsing(t *testing.T) {
+	defer debugOff()
 	DebugMode = true
 
 	ResetParser()
@@ -393,7 +394,6 @@ func TestInputParsing(t *testing.T) {
 	var maskSliceFlagExpected = []net.IPMask{net.IPMask([]byte{255, 255, 255, 255}), net.IPMask([]byte{255, 255, 255, 0})}
 
 	// Parse arguments
-	fmt.Println(inputArgs)
 	err = ParseArgs(inputArgs)
 	if err != nil {
 		t.Fatal(err)
@@ -401,7 +401,6 @@ func TestInputParsing(t *testing.T) {
 
 	// validate parsed values
 	if stringFlag != stringFlagExpected {
-		t.Log(stringFlag)
 		t.Fatal("string flag incorrect", stringFlag, stringFlagExpected)
 	}
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -401,6 +401,7 @@ func TestInputParsing(t *testing.T) {
 
 	// validate parsed values
 	if stringFlag != stringFlagExpected {
+		t.Log(stringFlag)
 		t.Fatal("string flag incorrect", stringFlag, stringFlagExpected)
 	}
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -1,9 +1,7 @@
 package flaggy
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -82,7 +80,7 @@ func TestInputParsing(t *testing.T) {
 
 	// Setup input arguments for every input type
 
-	var stringFlag string
+	var stringFlag string = "defaultVar"
 	err = AddStringFlag(&stringFlag, "s", "string", "string flag")
 	if err != nil {
 		t.Fatal(err)
@@ -119,8 +117,8 @@ func TestInputParsing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	inputArgs = append(inputArgs, "-bysf", "1111")
-	var byteSliceFlagExpected = bytes.NewBufferString("1111").Bytes()
+	inputArgs = append(inputArgs, "-bysf", "17", "-bysf", "18")
+	var byteSliceFlagExpected = []uint8{17, 18}
 
 	var durationFlag time.Duration
 	err = AddDurationFlag(&durationFlag, "df", "duration", "duration flag")
@@ -263,8 +261,8 @@ func TestInputParsing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	inputArgs = append(inputArgs, "-ui8s", "40", "-ui8s", "50")
-	var uint8SliceFlagExpected = []uint8{40, 50}
+	inputArgs = append(inputArgs, "-ui8s", "3", "-ui8s", "2")
+	var uint8SliceFlagExpected = []uint8{uint8(3), uint8(2)}
 
 	var int64Flag int64
 	err = AddInt64Flag(&int64Flag, "i64", "i64", "int64 flag")
@@ -327,8 +325,8 @@ func TestInputParsing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	inputArgs = append(inputArgs, "-i8s", "40", "-i8s", "20")
-	var int8SliceFlagExpected = []int8{40, 20}
+	inputArgs = append(inputArgs, "-i8s", "4", "-i8s", "2")
+	var int8SliceFlagExpected = []int8{4, 2}
 
 	var ipFlag net.IP
 	err = AddIPFlag(&ipFlag, "ip", "ipFlag", "ip flag")
@@ -352,12 +350,10 @@ func TestInputParsing(t *testing.T) {
 		t.Fatal(err)
 	}
 	inputArgs = append(inputArgs, "-hw", "32:00:16:46:20:00")
-	buf := bytes.NewBufferString("32:00:16:46:20:00")
-	hwBytes, err := ioutil.ReadAll(buf)
+	hwFlagExpected, err := net.ParseMAC("32:00:16:46:20:00")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var hwFlagExpected = net.HardwareAddr(hwBytes)
 
 	var hwFlagSlice []net.HardwareAddr
 	err = AddHardwareAddrSliceFlag(&hwFlagSlice, "hws", "hwFlagSlice", "hw slice flag")
@@ -365,17 +361,15 @@ func TestInputParsing(t *testing.T) {
 		t.Fatal(err)
 	}
 	inputArgs = append(inputArgs, "-hws", "32:00:16:46:20:00", "-hws", "32:00:16:46:20:01")
-	bufA := bytes.NewBufferString("32:00:16:46:20:00")
-	bufB := bytes.NewBufferString("32:00:16:46:20:01")
-	hwBytesA, err := ioutil.ReadAll(bufA)
+	macA, err := net.ParseMAC("32:00:16:46:20:00")
 	if err != nil {
 		t.Fatal(err)
 	}
-	hwBytesB, err := ioutil.ReadAll(bufB)
+	macB, err := net.ParseMAC("32:00:16:46:20:01")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var hwFlagSliceExpected = []net.HardwareAddr{net.HardwareAddr(hwBytesA), net.HardwareAddr(hwBytesB)}
+	var hwFlagSliceExpected = []net.HardwareAddr{macA, macB}
 
 	var maskFlag net.IPMask
 	err = AddIPMaskFlag(&maskFlag, "m", "mFlag", "mask flag")
@@ -512,7 +506,7 @@ func TestInputParsing(t *testing.T) {
 
 	for i, f := range uint8SliceFlagExpected {
 		if uint8SliceFlag[i] != f {
-			t.Fatal("uint8Slice value incorrect", uint8SliceFlag[i], f)
+			t.Fatal("uint8Slice value", i, "incorrect", uint8SliceFlag[i], f)
 		}
 	}
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -73,6 +73,7 @@ func TestDetermineArgType(t *testing.T) {
 
 // TestInputParsing tests all flag types.
 func TestInputParsing(t *testing.T) {
+	DebugMode = true
 
 	ResetParser()
 	var err error
@@ -87,8 +88,6 @@ func TestInputParsing(t *testing.T) {
 	}
 	inputArgs = append(inputArgs, "-s", "flaggy")
 	var stringFlagExpected = "flaggy"
-	// TODO - input args for every flag
-	// TODO - desired output for every flag
 
 	var stringSliceFlag []string
 	err = AddStringSliceFlag(&stringSliceFlag, "ssf", "stringSlice", "string slice flag")
@@ -160,7 +159,7 @@ func TestInputParsing(t *testing.T) {
 		t.Fatal(err)
 	}
 	inputArgs = append(inputArgs, "-f64", "33.222343")
-	var float64FlagExpected float64 = 33.222343
+	var float64FlagExpected = 33.222343
 
 	var float64SliceFlag []float64
 	err = AddFloat64SliceFlag(&float64SliceFlag, "f64s", "float64Slice", "float64 slice flag")
@@ -176,7 +175,7 @@ func TestInputParsing(t *testing.T) {
 		t.Fatal(err)
 	}
 	inputArgs = append(inputArgs, "-i", "3553")
-	var intFlagExpected int = 3553
+	var intFlagExpected = 3553
 
 	var intSliceFlag []int
 	err = AddIntSliceFlag(&intSliceFlag, "is", "intSlice", "int slice flag")
@@ -275,7 +274,7 @@ func TestInputParsing(t *testing.T) {
 	var int64FlagExpected int64 = 33445566
 
 	var int64SliceFlag []int64
-	err = AddInt64SliceFlag(&int64SliceFlag, "i64s", "uint64Slice", "int64 slice flag")
+	err = AddInt64SliceFlag(&int64SliceFlag, "i64s", "int64Slice", "int64 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +290,7 @@ func TestInputParsing(t *testing.T) {
 	var int32FlagExpected int32 = 445566
 
 	var int32SliceFlag []int32
-	err = AddInt32SliceFlag(&int32SliceFlag, "ui32s", "uint32Slice", "uint32 slice flag")
+	err = AddInt32SliceFlag(&int32SliceFlag, "i32s", "int32Slice", "uint32 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +322,7 @@ func TestInputParsing(t *testing.T) {
 	var int8FlagExpected int8 = 32
 
 	var int8SliceFlag []int8
-	err = AddInt8SliceFlag(&int8SliceFlag, "i8s", "uint8Slice", "uint8 slice flag")
+	err = AddInt8SliceFlag(&int8SliceFlag, "i8s", "int8Slice", "uint8 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +356,7 @@ func TestInputParsing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var hwFlagExpected net.HardwareAddr = net.HardwareAddr(hwBytes)
+	var hwFlagExpected = net.HardwareAddr(hwBytes)
 
 	var hwFlagSlice []net.HardwareAddr
 	err = AddHardwareAddrSliceFlag(&hwFlagSlice, "hws", "hwFlagSlice", "hw slice flag")
@@ -375,7 +374,7 @@ func TestInputParsing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var hwFlagSliceExpected []net.HardwareAddr = []net.HardwareAddr{net.HardwareAddr(hwBytesA), net.HardwareAddr(hwBytesB)}
+	var hwFlagSliceExpected = []net.HardwareAddr{net.HardwareAddr(hwBytesA), net.HardwareAddr(hwBytesB)}
 
 	var maskFlag net.IPMask
 	err = AddIPMaskFlag(&maskFlag, "m", "mFlag", "mask flag")
@@ -394,6 +393,7 @@ func TestInputParsing(t *testing.T) {
 	var maskSliceFlagExpected = []net.IPMask{net.IPMask([]byte{255, 255, 255, 255}), net.IPMask([]byte{255, 255, 255, 0})}
 
 	// Parse arguments
+	fmt.Println(inputArgs)
 	err = ParseArgs(inputArgs)
 	if err != nil {
 		t.Fatal(err)

--- a/flag_test.go
+++ b/flag_test.go
@@ -2,8 +2,10 @@ package flaggy
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"testing"
+	"time"
 )
 
 // debugOff makes defers easier
@@ -67,40 +69,243 @@ func TestDetermineArgType(t *testing.T) {
 	}
 }
 
-// *string
-// *[]string
-// *bool
-// *[]bool
-// *[]byte
-// *time.Duration
-// *[]time.Duration
-// *float32
-// *[]float32
-// *float64
-// *[]float64
-// *int
-// *[]int
-// *uint
-// *[]uint
-// *uint64
-// *[]uint64
-// *uint32
-// *[]uint32
-// *uint16
-// *[]uint16
-// *uint8
-// *[]uint8
-// *int64
-// *[]int64
-// *int32
-// *[]int32
-// *int16
-// *[]int16
-// *int8
-// *[]int8
-// *net.IP
-// *[]net.IP
-// *net.HardwareAddr
-// *[]net.HardwareAddr
-// *net.IPMask
-// *[]net.IPMask
+// TestInputParsing tests all flag types.
+func TestInputParsing(t *testing.T) {
+
+	var err error
+
+	ResetParser()
+
+	inputArgs := []string{}
+
+	var stringFlag string
+	err = AddStringFlag(&stringFlag, "s", "string", "string flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputArgs = append(inputArgs, "-s", "flaggy")
+	// TODO - input args for every flag
+	// TODO - desired output for every flag
+
+	var stringSliceFlag []string
+	err = AddStringSliceFlag(&stringSliceFlag, "ssf", "stringSlice", "string slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var boolFlag bool
+	err = AddBoolFlag(&boolFlag, "bf", "bool", "bool flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var boolSliceFlag []bool
+	err = AddBoolSliceFlag(&boolSliceFlag, "bsf", "boolSlice", "bool slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var byteSliceFlag []byte
+	err = AddByteSliceFlag(&byteSliceFlag, "bysf", "byteSlice", "byte slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var durationFlag time.Duration
+	err = AddDurationFlag(&durationFlag, "df", "duration", "duration flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var durationSliceFlag []time.Duration
+	err = AddDurationSliceFlag(&durationSliceFlag, "dsf", "durationSlice", "duration slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var float32Flag float32
+	err = AddFloat32Flag(&float32Flag, "f32", "float32", "float32 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var float32SliceFlag []float32
+	err = AddFloat32SliceFlag(&float32SliceFlag, "f32s", "float32Slice", "float32 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var float64Flag float64
+	err = AddFloat64Flag(&float64Flag, "f64", "float64", "float64 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var float64SliceFlag []float64
+	err = AddFloat64SliceFlag(&float64SliceFlag, "f64s", "float64Slice", "float64 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var intFlag int
+	err = AddIntFlag(&intFlag, "i", "int", "int flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var intSliceFlag []int
+	err = AddIntSliceFlag(&intSliceFlag, "is", "intSlice", "int slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uintFlag uint
+	err = AddUIntFlag(&uintFlag, "ui", "uint", "uint flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uintSliceFlag []uint
+	err = AddUIntSliceFlag(&uintSliceFlag, "uis", "uintSlice", "uint slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uint64Flag uint64
+	err = AddUInt64Flag(&uint64Flag, "ui64", "uint64", "uint64 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uint64SliceFlag []uint64
+	err = AddUInt64SliceFlag(&uint64SliceFlag, "ui64s", "uint64Slice", "uint64 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uint32Flag uint32
+	err = AddUInt32Flag(&uint32Flag, "ui32", "uint32", "uint32 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uint32SliceFlag []uint32
+	err = AddUInt32SliceFlag(&uint32SliceFlag, "ui32s", "uint32Slice", "uint32 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uint16Flag uint16
+	err = AddUInt16Flag(&uint16Flag, "ui16", "uint16", "uint16 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uint16SliceFlag []uint16
+	err = AddUInt16SliceFlag(&uint16SliceFlag, "ui16s", "uint16Slice", "uint16 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uint8Flag uint8
+	err = AddUInt8Flag(&uint8Flag, "ui8", "uint8", "uint8 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var uint8SliceFlag []uint8
+	err = AddUInt8SliceFlag(&uint8SliceFlag, "ui8s", "uint8Slice", "uint8 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var int64Flag int64
+	err = AddInt64Flag(&int64Flag, "i64", "int64", "int64 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var int64SliceFlag []int64
+	err = AddInt64SliceFlag(&int64SliceFlag, "ui64s", "uint64Slice", "uint64 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var int32Flag int32
+	err = AddInt32Flag(&int32Flag, "i32", "int32", "int32 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var int32SliceFlag []int32
+	err = AddInt32SliceFlag(&int32SliceFlag, "ui32s", "uint32Slice", "uint32 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var int16Flag int16
+	err = AddInt16Flag(&int16Flag, "i16", "int16", "int16 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var int16SliceFlag []int16
+	err = AddInt16SliceFlag(&int16SliceFlag, "ui16s", "uint16Slice", "uint16 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var int8Flag int8
+	err = AddInt8Flag(&int8Flag, "i8", "int8", "int8 flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var int8SliceFlag []int8
+	err = AddInt8SliceFlag(&int8SliceFlag, "ui8s", "uint8Slice", "uint8 slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ipFlag net.IP
+	err = AddIPFlag(&ipFlag, "ip", "ipFlag", "ip flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ipSliceFlag []net.IP
+	err = AddIPSliceFlag(&ipSliceFlag, "ips", "ipFlagSlice", "ip slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var hwFlag net.HardwareAddr
+	err = AddHardwareAddrFlag(&hwFlag, "hw", "hwFlag", "hw flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var hwFlagSlice []net.HardwareAddr
+	err = AddHardwareAddrSliceFlag(&hwFlagSlice, "hws", "hwFlagSlice", "hw slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var maskFlag net.IPMask
+	err = AddIPMaskFlag(&maskFlag, "m", "mFlag", "mask flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var maskSliceFlag []net.IPMask
+	err = AddIPMaskSliceFlag(&maskSliceFlag, "ms", "mFlagSlice", "mask slice flag")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ParseArgs(inputArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/flag_test.go
+++ b/flag_test.go
@@ -66,3 +66,41 @@ func TestDetermineArgType(t *testing.T) {
 		}
 	}
 }
+
+// *string
+// *[]string
+// *bool
+// *[]bool
+// *[]byte
+// *time.Duration
+// *[]time.Duration
+// *float32
+// *[]float32
+// *float64
+// *[]float64
+// *int
+// *[]int
+// *uint
+// *[]uint
+// *uint64
+// *[]uint64
+// *uint32
+// *[]uint32
+// *uint16
+// *[]uint16
+// *uint8
+// *[]uint8
+// *int64
+// *[]int64
+// *int32
+// *[]int32
+// *int16
+// *[]int16
+// *int8
+// *[]int8
+// *net.IP
+// *[]net.IP
+// *net.HardwareAddr
+// *[]net.HardwareAddr
+// *net.IPMask
+// *[]net.IPMask

--- a/flag_test.go
+++ b/flag_test.go
@@ -1,7 +1,9 @@
 package flaggy
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -72,11 +74,11 @@ func TestDetermineArgType(t *testing.T) {
 // TestInputParsing tests all flag types.
 func TestInputParsing(t *testing.T) {
 
-	var err error
-
 	ResetParser()
-
+	var err error
 	inputArgs := []string{}
+
+	// Setup input arguments for every input type
 
 	var stringFlag string
 	err = AddStringFlag(&stringFlag, "s", "string", "string flag")
@@ -84,6 +86,7 @@ func TestInputParsing(t *testing.T) {
 		t.Fatal(err)
 	}
 	inputArgs = append(inputArgs, "-s", "flaggy")
+	var stringFlagExpected = "flaggy"
 	// TODO - input args for every flag
 	// TODO - desired output for every flag
 
@@ -92,220 +95,494 @@ func TestInputParsing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ssf", "one", "-ssf", "two")
+	var stringSliceFlagExpected = []string{"one", "two"}
 
 	var boolFlag bool
 	err = AddBoolFlag(&boolFlag, "bf", "bool", "bool flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-bf")
+	var boolFlagExpected = true
 
 	var boolSliceFlag []bool
 	err = AddBoolSliceFlag(&boolSliceFlag, "bsf", "boolSlice", "bool slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-bsf", "-bsf")
+	var boolSliceFlagExpected = []bool{true, true}
 
 	var byteSliceFlag []byte
 	err = AddByteSliceFlag(&byteSliceFlag, "bysf", "byteSlice", "byte slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-bysf", "1111")
+	var byteSliceFlagExpected = bytes.NewBufferString("1111").Bytes()
 
 	var durationFlag time.Duration
 	err = AddDurationFlag(&durationFlag, "df", "duration", "duration flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-df", "33s")
+	var durationFlagExpected = time.Second * 33
 
 	var durationSliceFlag []time.Duration
 	err = AddDurationSliceFlag(&durationSliceFlag, "dsf", "durationSlice", "duration slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-dsf", "33s", "-dsf", "1h")
+	var durationSliceFlagExpected = []time.Duration{time.Second * 33, time.Hour}
 
 	var float32Flag float32
 	err = AddFloat32Flag(&float32Flag, "f32", "float32", "float32 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-f32", "33.343")
+	var float32FlagExpected float32 = 33.343
 
 	var float32SliceFlag []float32
 	err = AddFloat32SliceFlag(&float32SliceFlag, "f32s", "float32Slice", "float32 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-f32s", "33.343", "-f32s", "33.222")
+	var float32SliceFlagExpected = []float32{33.343, 33.222}
 
 	var float64Flag float64
 	err = AddFloat64Flag(&float64Flag, "f64", "float64", "float64 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-f64", "33.222343")
+	var float64FlagExpected float64 = 33.222343
 
 	var float64SliceFlag []float64
 	err = AddFloat64SliceFlag(&float64SliceFlag, "f64s", "float64Slice", "float64 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-f64s", "64.343", "-f64s", "64.222")
+	var float64SliceFlagExpected = []float64{64.343, 64.222}
 
 	var intFlag int
 	err = AddIntFlag(&intFlag, "i", "int", "int flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-i", "3553")
+	var intFlagExpected int = 3553
 
 	var intSliceFlag []int
 	err = AddIntSliceFlag(&intSliceFlag, "is", "intSlice", "int slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-is", "6446", "-is", "64")
+	var intSliceFlagExpected = []int{6446, 64}
 
 	var uintFlag uint
 	err = AddUIntFlag(&uintFlag, "ui", "uint", "uint flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ui", "3553")
+	var uintFlagExpected uint = 3553
 
 	var uintSliceFlag []uint
 	err = AddUIntSliceFlag(&uintSliceFlag, "uis", "uintSlice", "uint slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-uis", "6446", "-uis", "64")
+	var uintSliceFlagExpected = []uint{6446, 64}
 
 	var uint64Flag uint64
 	err = AddUInt64Flag(&uint64Flag, "ui64", "uint64", "uint64 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ui64", "3553")
+	var uint64FlagExpected uint64 = 3553
 
 	var uint64SliceFlag []uint64
 	err = AddUInt64SliceFlag(&uint64SliceFlag, "ui64s", "uint64Slice", "uint64 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ui64s", "6446", "-ui64s", "64")
+	var uint64SliceFlagExpected = []uint64{6446, 64}
 
 	var uint32Flag uint32
 	err = AddUInt32Flag(&uint32Flag, "ui32", "uint32", "uint32 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ui32", "6446")
+	var uint32FlagExpected uint32 = 6446
 
 	var uint32SliceFlag []uint32
 	err = AddUInt32SliceFlag(&uint32SliceFlag, "ui32s", "uint32Slice", "uint32 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ui32s", "6446", "-ui32s", "64")
+	var uint32SliceFlagExpected = []uint32{6446, 64}
 
 	var uint16Flag uint16
 	err = AddUInt16Flag(&uint16Flag, "ui16", "uint16", "uint16 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ui16", "6446")
+	var uint16FlagExpected uint16 = 6446
 
 	var uint16SliceFlag []uint16
 	err = AddUInt16SliceFlag(&uint16SliceFlag, "ui16s", "uint16Slice", "uint16 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ui16s", "6446", "-ui16s", "64")
+	var uint16SliceFlagExpected = []uint16{6446, 64}
 
 	var uint8Flag uint8
 	err = AddUInt8Flag(&uint8Flag, "ui8", "uint8", "uint8 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ui8", "50")
+	var uint8FlagExpected uint8 = 50
 
 	var uint8SliceFlag []uint8
 	err = AddUInt8SliceFlag(&uint8SliceFlag, "ui8s", "uint8Slice", "uint8 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ui8s", "40", "-ui8s", "50")
+	var uint8SliceFlagExpected = []uint8{40, 50}
 
 	var int64Flag int64
-	err = AddInt64Flag(&int64Flag, "i64", "int64", "int64 flag")
+	err = AddInt64Flag(&int64Flag, "i64", "i64", "int64 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-i64", "33445566")
+	var int64FlagExpected int64 = 33445566
 
 	var int64SliceFlag []int64
-	err = AddInt64SliceFlag(&int64SliceFlag, "ui64s", "uint64Slice", "uint64 slice flag")
+	err = AddInt64SliceFlag(&int64SliceFlag, "i64s", "uint64Slice", "int64 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-i64s", "40", "-i64s", "50")
+	var int64SliceFlagExpected = []int64{40, 50}
 
 	var int32Flag int32
 	err = AddInt32Flag(&int32Flag, "i32", "int32", "int32 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-i32", "445566")
+	var int32FlagExpected int32 = 445566
 
 	var int32SliceFlag []int32
 	err = AddInt32SliceFlag(&int32SliceFlag, "ui32s", "uint32Slice", "uint32 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-i32s", "40", "-i32s", "50")
+	var int32SliceFlagExpected = []int32{40, 50}
 
 	var int16Flag int16
 	err = AddInt16Flag(&int16Flag, "i16", "int16", "int16 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-i16", "5566")
+	var int16FlagExpected int16 = 5566
 
 	var int16SliceFlag []int16
-	err = AddInt16SliceFlag(&int16SliceFlag, "ui16s", "uint16Slice", "uint16 slice flag")
+	err = AddInt16SliceFlag(&int16SliceFlag, "i16s", "int16Slice", "int16 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-i16s", "40", "-i16s", "50")
+	var int16SliceFlagExpected = []int16{40, 50}
 
 	var int8Flag int8
 	err = AddInt8Flag(&int8Flag, "i8", "int8", "int8 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-i8", "32")
+	var int8FlagExpected int8 = 32
 
 	var int8SliceFlag []int8
-	err = AddInt8SliceFlag(&int8SliceFlag, "ui8s", "uint8Slice", "uint8 slice flag")
+	err = AddInt8SliceFlag(&int8SliceFlag, "i8s", "uint8Slice", "uint8 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-i8s", "40", "-i8s", "20")
+	var int8SliceFlagExpected = []int8{40, 20}
 
 	var ipFlag net.IP
 	err = AddIPFlag(&ipFlag, "ip", "ipFlag", "ip flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ip", "1.1.1.1")
+	var ipFlagExpected = net.IPv4(1, 1, 1, 1)
 
 	var ipSliceFlag []net.IP
 	err = AddIPSliceFlag(&ipSliceFlag, "ips", "ipFlagSlice", "ip slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ips", "1.1.1.1", "-ips", "4.4.4.4")
+	var ipSliceFlagExpected = []net.IP{net.IPv4(1, 1, 1, 1), net.IPv4(4, 4, 4, 4)}
 
 	var hwFlag net.HardwareAddr
 	err = AddHardwareAddrFlag(&hwFlag, "hw", "hwFlag", "hw flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-hw", "32:00:16:46:20:00")
+	buf := bytes.NewBufferString("32:00:16:46:20:00")
+	hwBytes, err := ioutil.ReadAll(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hwFlagExpected net.HardwareAddr = net.HardwareAddr(hwBytes)
 
 	var hwFlagSlice []net.HardwareAddr
 	err = AddHardwareAddrSliceFlag(&hwFlagSlice, "hws", "hwFlagSlice", "hw slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-hws", "32:00:16:46:20:00", "-hws", "32:00:16:46:20:01")
+	bufA := bytes.NewBufferString("32:00:16:46:20:00")
+	bufB := bytes.NewBufferString("32:00:16:46:20:01")
+	hwBytesA, err := ioutil.ReadAll(bufA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hwBytesB, err := ioutil.ReadAll(bufB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hwFlagSliceExpected []net.HardwareAddr = []net.HardwareAddr{net.HardwareAddr(hwBytesA), net.HardwareAddr(hwBytesB)}
 
 	var maskFlag net.IPMask
 	err = AddIPMaskFlag(&maskFlag, "m", "mFlag", "mask flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-m", "255.255.255.255")
+	var maskFlagExpected = net.IPMask([]byte{255, 255, 255, 255})
 
 	var maskSliceFlag []net.IPMask
 	err = AddIPMaskSliceFlag(&maskSliceFlag, "ms", "mFlagSlice", "mask slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
+	inputArgs = append(inputArgs, "-ms", "255.255.255.255", "-ms", "255.255.255.0")
+	var maskSliceFlagExpected = []net.IPMask{net.IPMask([]byte{255, 255, 255, 255}), net.IPMask([]byte{255, 255, 255, 0})}
 
+	// Parse arguments
 	err = ParseArgs(inputArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// validate parsed values
+	if stringFlag != stringFlagExpected {
+		t.Fatal("string flag incorrect", stringFlag, stringFlagExpected)
+	}
+
+	for i, f := range stringSliceFlagExpected {
+		if stringSliceFlag[i] != f {
+			t.Fatal("stringSlice value incorrect", stringSliceFlag[i], f)
+		}
+	}
+
+	if boolFlag != boolFlagExpected {
+		t.Fatal("bool flag incorrect", boolFlag, boolFlagExpected)
+	}
+
+	for i, f := range boolSliceFlagExpected {
+		if boolSliceFlag[i] != f {
+			t.Fatal("boolSlice value incorrect", boolSliceFlag[i], f)
+		}
+	}
+
+	for i, f := range byteSliceFlagExpected {
+		if byteSliceFlag[i] != f {
+			t.Fatal("byteSlice value incorrect", boolSliceFlag[i], f)
+		}
+	}
+
+	if durationFlag != durationFlagExpected {
+		t.Fatal("duration flag incorrect", durationFlag, durationFlagExpected)
+	}
+
+	for i, f := range durationSliceFlagExpected {
+		if durationSliceFlag[i] != f {
+			t.Fatal("durationSlice value incorrect", durationSliceFlag[i], f)
+		}
+	}
+
+	if float32Flag != float32FlagExpected {
+		t.Fatal("float32 flag incorrect", float32Flag, float32FlagExpected)
+	}
+
+	for i, f := range float32SliceFlagExpected {
+		if float32SliceFlag[i] != f {
+			t.Fatal("float32Slice value incorrect", float32SliceFlag[i], f)
+		}
+	}
+
+	if float64Flag != float64FlagExpected {
+		t.Fatal("float64 flag incorrect", float64Flag, float64FlagExpected)
+	}
+
+	for i, f := range float64SliceFlagExpected {
+		if float64SliceFlag[i] != f {
+			t.Fatal("float64Slice value incorrect", float64SliceFlag[i], f)
+		}
+	}
+
+	if intFlag != intFlagExpected {
+		t.Fatal("int flag incorrect", intFlag, intFlagExpected)
+	}
+
+	for i, f := range intSliceFlagExpected {
+		if intSliceFlag[i] != f {
+			t.Fatal("intSlice value incorrect", intSliceFlag[i], f)
+		}
+	}
+
+	if uintFlag != uintFlagExpected {
+		t.Fatal("uint flag incorrect", uintFlag, uintFlagExpected)
+	}
+
+	for i, f := range uintSliceFlagExpected {
+		if uintSliceFlag[i] != f {
+			t.Fatal("uintSlice value incorrect", uintSliceFlag[i], f)
+		}
+	}
+
+	if uint64Flag != uint64FlagExpected {
+		t.Fatal("uint64 flag incorrect", uint64Flag, uint64FlagExpected)
+	}
+
+	for i, f := range uint64SliceFlagExpected {
+		if uint64SliceFlag[i] != f {
+			t.Fatal("uint64Slice value incorrect", uint64SliceFlag[i], f)
+		}
+	}
+
+	if uint32Flag != uint32FlagExpected {
+		t.Fatal("uint32 flag incorrect", uint32Flag, uint32FlagExpected)
+	}
+
+	for i, f := range uint32SliceFlagExpected {
+		if uint32SliceFlag[i] != f {
+			t.Fatal("uint32Slice value incorrect", uint32SliceFlag[i], f)
+		}
+	}
+
+	if uint16Flag != uint16FlagExpected {
+		t.Fatal("uint16 flag incorrect", uint16Flag, uint16FlagExpected)
+	}
+
+	for i, f := range uint16SliceFlagExpected {
+		if uint16SliceFlag[i] != f {
+			t.Fatal("uint16Slice value incorrect", uint16SliceFlag[i], f)
+		}
+	}
+
+	if uint8Flag != uint8FlagExpected {
+		t.Fatal("uint8 flag incorrect", uint8Flag, uint8FlagExpected)
+	}
+
+	for i, f := range uint8SliceFlagExpected {
+		if uint8SliceFlag[i] != f {
+			t.Fatal("uint8Slice value incorrect", uint8SliceFlag[i], f)
+		}
+	}
+
+	if int64Flag != int64FlagExpected {
+		t.Fatal("int64 flag incorrect", int64Flag, int64FlagExpected)
+	}
+
+	for i, f := range int64SliceFlagExpected {
+		if int64SliceFlag[i] != f {
+			t.Fatal("int64Slice value incorrect", int64SliceFlag[i], f)
+		}
+	}
+
+	if int32Flag != int32FlagExpected {
+		t.Fatal("int32 flag incorrect", int32Flag, int32FlagExpected)
+	}
+
+	for i, f := range int32SliceFlagExpected {
+		if int32SliceFlag[i] != f {
+			t.Fatal("int32Slice value incorrect", int32SliceFlag[i], f)
+		}
+	}
+
+	if int16Flag != int16FlagExpected {
+		t.Fatal("int16 flag incorrect", int16Flag, int16FlagExpected)
+	}
+
+	for i, f := range int16SliceFlagExpected {
+		if int16SliceFlag[i] != f {
+			t.Fatal("int16Slice value incorrect", int16SliceFlag[i], f)
+		}
+	}
+
+	if int8Flag != int8FlagExpected {
+		t.Fatal("int8 flag incorrect", int8Flag, int8FlagExpected)
+	}
+
+	for i, f := range int8SliceFlagExpected {
+		if int8SliceFlag[i] != f {
+			t.Fatal("int8Slice value incorrect", int8SliceFlag[i], f)
+		}
+	}
+
+	if !ipFlag.Equal(ipFlagExpected) {
+		t.Fatal("ip flag incorrect", ipFlag, ipFlagExpected)
+	}
+
+	for i, f := range ipSliceFlagExpected {
+		if !f.Equal(ipSliceFlag[i]) {
+			t.Fatal("ipSlice value incorrect", ipSliceFlag[i], f)
+		}
+	}
+
+	if hwFlag.String() != hwFlagExpected.String() {
+		t.Fatal("hw flag incorrect", hwFlag, hwFlagExpected)
+	}
+
+	for i, f := range hwFlagSliceExpected {
+		if f.String() != hwFlagSlice[i].String() {
+			t.Fatal("hw flag slice value incorrect", hwFlagSlice[i].String(), f.String())
+		}
+	}
+
+	if maskFlag.String() != maskFlagExpected.String() {
+		t.Fatal("mask flag incorrect", maskFlag, maskFlagExpected)
+	}
+
+	for i, f := range maskSliceFlagExpected {
+		if f.String() != maskSliceFlag[i].String() {
+			t.Fatal("mask flag slice value incorrect", maskSliceFlag[i].String(), f.String())
+		}
+	}
 }

--- a/help.go
+++ b/help.go
@@ -14,7 +14,7 @@ const defaultHelpTemplate = `{{.CommandName}}{{if .Description}} - {{.Descriptio
 
   Subcommands: {{range .Subcommands}}
     {{.LongName}}{{if .ShortName}} ({{.ShortName}}){{end}} -{{if .Position}}{{if gt .Position 1}} (Position {{.Position}}){{end}}{{end}}{{if .Description}} {{.Description}}{{end}}{{end}}
-{{end}}{{if (or (or (gt (len .StringFlags) 0) (gt (len .IntFlags) 0)) (gt (len .BoolFlags) 0))}}
+{{end}}{{if (gt (len .Flags) 0)}}
   Flags: {{if .Flags}}{{range .Flags}}
     {{if .ShortName}}-{{.ShortName}} {{else}}   {{end}}{{if .LongName}}--{{.LongName}} {{end}}{{if .Description}} {{.Description}}{{end}}{{end}}{{end}}
 {{end}}

--- a/help.go
+++ b/help.go
@@ -15,10 +15,7 @@ const defaultHelpTemplate = `{{.CommandName}}{{if .Description}} - {{.Descriptio
   Subcommands: {{range .Subcommands}}
     {{.LongName}}{{if .ShortName}} ({{.ShortName}}){{end}} -{{if .Position}}{{if gt .Position 1}} (Position {{.Position}}){{end}}{{end}}{{if .Description}} {{.Description}}{{end}}{{end}}
 {{end}}{{if (or (or (gt (len .StringFlags) 0) (gt (len .IntFlags) 0)) (gt (len .BoolFlags) 0))}}
-  Flags: {{if .StringFlags}}{{range .StringFlags}}
-    {{if .ShortName}}-{{.ShortName}} {{else}}   {{end}}{{if .LongName}}--{{.LongName}} {{end}}{{if .Description}} {{.Description}}{{end}}{{end}}{{end}}{{if .IntFlags}}{{range .IntFlags}}
-    {{if .ShortName}}-{{.ShortName}} {{else}}   {{end}}{{if .LongName}}--{{.LongName}} {{end}}{{if .Description}} {{.Description}}{{end}}{{end}}{{end}}{{if .BoolFlags}}{{range .BoolFlags}}
-    {{if .ShortName}}-{{.ShortName}} {{else}}   {{end}}{{if .LongName}}--{{.LongName}} {{end}}{{if .Description}} {{.Description}}{{end}}{{end}}{{end}}{{if .DurationFlags}}{{range .DurationFlags}}
+  Flags: {{if .Flags}}{{range .Flags}}
     {{if .ShortName}}-{{.ShortName}} {{else}}   {{end}}{{if .LongName}}--{{.LongName}} {{end}}{{if .Description}} {{.Description}}{{end}}{{end}}{{end}}
 {{end}}
 {{if .AppendMessage}}{{.AppendMessage}}

--- a/helpValues.go
+++ b/helpValues.go
@@ -4,10 +4,7 @@ package flaggy
 type Help struct {
 	Subcommands    []HelpSubcommand
 	Positionals    []HelpPositional
-	StringFlags    []HelpFlag
-	IntFlags       []HelpFlag
-	BoolFlags      []HelpFlag
-	DurationFlags  []HelpFlag
+	Flags          []HelpFlag
 	UsageString    string
 	CommandName    string
 	PrependMessage string
@@ -79,7 +76,7 @@ func (h *Help) ExtractValues(sc *Subcommand, message string) {
 		h.Positionals = append(h.Positionals, newHelpPositional)
 	}
 
-	for _, f := range sc.StringFlags {
+	for _, f := range sc.Flags {
 		if f.Hidden {
 			continue
 		}
@@ -88,42 +85,8 @@ func (h *Help) ExtractValues(sc *Subcommand, message string) {
 			LongName:    f.LongName,
 			Description: f.Description,
 		}
-		h.StringFlags = append(h.StringFlags, newHelpFlag)
+		h.Flags = append(h.Flags, newHelpFlag)
 	}
-	for _, f := range sc.IntFlags {
-		if f.Hidden {
-			continue
-		}
-		newHelpFlag := HelpFlag{
-			ShortName:   f.ShortName,
-			LongName:    f.LongName,
-			Description: f.Description,
-		}
-		h.IntFlags = append(h.IntFlags, newHelpFlag)
-	}
-	for _, f := range sc.BoolFlags {
-		if f.Hidden {
-			continue
-		}
-		newHelpFlag := HelpFlag{
-			ShortName:   f.ShortName,
-			LongName:    f.LongName,
-			Description: f.Description,
-		}
-		h.BoolFlags = append(h.BoolFlags, newHelpFlag)
-	}
-	for _, f := range sc.DurationFlags {
-		if f.Hidden {
-			continue
-		}
-		newHelpFlag := HelpFlag{
-			ShortName:   f.ShortName,
-			LongName:    f.LongName,
-			Description: f.Description,
-		}
-		h.DurationFlags = append(h.DurationFlags, newHelpFlag)
-	}
-
 	// formulate the usage string
 	// first, we capture all the command and positional names by position
 	commandsByPosition := make(map[int]string)

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ package flaggy
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -85,28 +86,207 @@ func ParseArgs(args []string) error {
 	return err
 }
 
-// AddBoolFlag adds a bool flag for parsing, at the global level of the
-// default parser
-func AddBoolFlag(assignmentVar *bool, shortName string, longName string, description string) error {
-	return mainParser.AddBoolFlag(assignmentVar, shortName, longName, description)
-}
-
-// AddIntFlag adds an int flag for parsing, at the global level of the
-// default parser
-func AddIntFlag(assignmentVar *int, shortName string, longName string, description string) error {
-	return mainParser.AddIntFlag(assignmentVar, shortName, longName, description)
-}
-
-// AddStringFlag adds a string flag for parsing, at the global level of the
-// default parser
+// AddStringFlag adds a new string flag
 func AddStringFlag(assignmentVar *string, shortName string, longName string, description string) error {
-	return mainParser.AddStringFlag(assignmentVar, shortName, longName, description)
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
 }
 
-// AddDurationFlag adds a duration flag for parsing, at the global level of the
-// default parser
+// AddStringSliceFlag adds a new slice of strings flag
+// Specify the flag multiple times to fill the slice
+func AddStringSliceFlag(assignmentVar *[]string, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddBoolFlag adds a new bool flag
+func AddBoolFlag(assignmentVar *bool, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddBoolSliceFlag adds a new slice of bools flag
+// Specify the flag multiple times to fill the slice
+func AddBoolSliceFlag(assignmentVar *[]bool, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddByteSliceFlag adds a new slice of bytes flag
+// Specify the flag multiple times to fill the slice.  Takes hex as input.
+func AddByteSliceFlag(assignmentVar *[]byte, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddDurationFlag adds a new time.Duration flag.
+// Input format is described in time.ParseDuration().
+// Example values: 1h, 1h50m, 32s
 func AddDurationFlag(assignmentVar *time.Duration, shortName string, longName string, description string) error {
-	return mainParser.AddDurationFlag(assignmentVar, shortName, longName, description)
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddDurationSliceFlag adds a new time.Duration flag.
+// Input format is described in time.ParseDuration().
+// Example values: 1h, 1h50m, 32s
+// Specify the flag multiple times to fill the slice.
+func AddDurationSliceFlag(assignmentVar *[]time.Duration, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddFloat32Flag adds a new float32 flag.
+func AddFloat32Flag(assignmentVar *float32, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddFloat32SliceFlag adds a new float32 flag.
+// Specify the flag multiple times to fill the slice.
+func AddFloat32SliceFlag(assignmentVar *[]float32, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddFloat64Flag adds a new float64 flag.
+func AddFloat64Flag(assignmentVar *float64, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddFloat64SliceFlag adds a new float64 flag.
+// Specify the flag multiple times to fill the slice.
+func AddFloat64SliceFlag(assignmentVar *[]float64, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddIntFlag adds a new int flag
+func AddIntFlag(assignmentVar *int, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddIntSliceFlag adds a new int slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddIntSliceFlag(assignmentVar *[]int, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUIntFlag adds a new uint flag
+func AddUIntFlag(assignmentVar *uint, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUIntSliceFlag adds a new uint slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddUIntSliceFlag(assignmentVar *[]uint, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt64Flag adds a new uint64 flag
+func AddUInt64Flag(assignmentVar *uint64, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt64SliceFlag adds a new uint64 slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddUInt64SliceFlag(assignmentVar *[]uint64, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt32Flag adds a new uint32 flag
+func AddUInt32Flag(assignmentVar *uint32, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt32SliceFlag adds a new uint32 slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddUInt32SliceFlag(assignmentVar *[]uint32, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt16Flag adds a new uint16 flag
+func AddUInt16Flag(assignmentVar *uint16, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt16SliceFlag adds a new uint16 slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddUInt16SliceFlag(assignmentVar *[]uint16, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt8Flag adds a new uint8 flag
+func AddUInt8Flag(assignmentVar *uint8, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt8SliceFlag adds a new uint8 slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddUInt8SliceFlag(assignmentVar *[]uint8, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt64SliceFlag adds a new int64 slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddInt64SliceFlag(assignmentVar *[]int64, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt32Flag adds a new int32 flag
+func AddInt32Flag(assignmentVar *int32, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt32SliceFlag adds a new int32 slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddInt32SliceFlag(assignmentVar *[]int32, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt16Flag adds a new int16 flag
+func AddInt16Flag(assignmentVar *int16, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt16SliceFlag adds a new int16 slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddInt16SliceFlag(assignmentVar *[]int16, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt8Flag adds a new int8 flag
+func AddInt8Flag(assignmentVar *int8, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt8SliceFlag adds a new int8 slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddInt8SliceFlag(assignmentVar *[]int8, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddIPFlag adds a new net.IP flag.
+func AddIPFlag(assignmentVar *net.IP, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddIPSliceFlag adds a new int8 slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddIPSliceFlag(assignmentVar *[]net.IP, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddHardwareAddrFlag adds a new net.HardwareAddr flag.
+func AddHardwareAddrFlag(assignmentVar *net.HardwareAddr, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddHardwareAddrSliceFlag adds a new net.HardwareAddr slice flag.
+// Specify the flag multiple times to fill the slice.
+func AddHardwareAddrSliceFlag(assignmentVar *[]net.HardwareAddr, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddIPMaskFlag adds a new net.IPMask flag. IPv4 Only.
+func AddIPMaskFlag(assignmentVar *net.IPMask, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddIPMaskSliceFlag adds a new net.HardwareAddr slice flag. IPv4 only.
+// Specify the flag multiple times to fill the slice.
+func AddIPMaskSliceFlag(assignmentVar *[]net.IPMask, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
 }
 
 // AddSubcommand adds a subcommand for parsing

--- a/main.go
+++ b/main.go
@@ -217,6 +217,11 @@ func AddUInt8SliceFlag(assignmentVar *[]uint8, shortName string, longName string
 	return mainParser.addFlag(assignmentVar, shortName, longName, description)
 }
 
+// AddInt64Flag adds a new int64 flag
+func AddInt64Flag(assignmentVar *int64, shortName string, longName string, description string) error {
+	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+}
+
 // AddInt64SliceFlag adds a new int64 slice flag.
 // Specify the flag multiple times to fill the slice.
 func AddInt64SliceFlag(assignmentVar *[]int64, shortName string, longName string, description string) error {

--- a/parser.go
+++ b/parser.go
@@ -37,10 +37,10 @@ func NewParser(name string) *Parser {
 // is returned for invalid arguments or missing require subcommands.
 func (p *Parser) ParseArgs(args []string) error {
 	if p.parsed {
-		return errors.New("Parser already parsed: " + " " + p.Name + " " + p.ShortName)
+		return errors.New("Parser.Parse() called twice on parser with name: " + " " + p.Name + " " + p.ShortName)
 	}
 	p.parsed = true
-	debugPrint("Kicking off parsing with args:", args)
+	// debugPrint("Kicking off parsing with args:", args)
 	return p.parse(p, args, 0)
 }
 

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,7 @@
 package flaggy
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
@@ -14,6 +15,7 @@ type Parser struct {
 	ShowVersionWithVFlag bool     // display the version when -v or --version passed
 	ShowHelpOnUnexpected bool     // display help when an unexpected flag is passed
 	TrailingArguments    []string // everything after a -- is placed here
+	parsed               bool     // indicates this parser has parsed
 }
 
 // NewParser creates a new ArgumentParser ready to parse inputs
@@ -34,6 +36,10 @@ func NewParser(name string) *Parser {
 // is a low level issue converting flags to their proper type.  No error
 // is returned for invalid arguments or missing require subcommands.
 func (p *Parser) ParseArgs(args []string) error {
+	if p.parsed {
+		return errors.New("Parser already parsed: " + " " + p.Name + " " + p.ShortName)
+	}
+	p.parsed = true
 	debugPrint("Kicking off parsing with args:", args)
 	return p.parse(p, args, 0)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,14 @@
+package flaggy
+
+import "testing"
+
+func TestDoubleParse(t *testing.T) {
+	err := mainParser.Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = mainParser.Parse()
+	if err == nil {
+		t.Fatal(err)
+	}
+}

--- a/subCommand.go
+++ b/subCommand.go
@@ -119,7 +119,7 @@ func (sc *Subcommand) parseAllFlagsFromArgs(p *Parser, args []string) ([]string,
 		argType := determineArgType(a)
 
 		// strip flags from arg
-		debugPrint("Parsing flag named", a, "of type", argType)
+		// debugPrint("Parsing flag named", a, "of type", argType)
 
 		// depending on the flag type, parse the key and value out, then apply it
 		switch argType {
@@ -132,9 +132,9 @@ func (sc *Subcommand) parseAllFlagsFromArgs(p *Parser, args []string) ([]string,
 			// we can determine if its a subcommand or positional value later
 			positionalOnlyArguments = append(positionalOnlyArguments, a)
 		case argIsFlagWithSpace:
-			skipNext = true
 			a = parseFlagToName(a)
 			// debugPrint("Arg", i, "is flag with space:", a)
+			skipNext = true
 			// parse next arg as value to this flag and apply to subcommand flags
 			// if the flag is a bool flag, then we check for a following positional
 			// and skip it if necessary
@@ -170,8 +170,8 @@ func (sc *Subcommand) parseAllFlagsFromArgs(p *Parser, args []string) ([]string,
 				return []string{}, false, err
 			}
 		case argIsFlagWithValue:
-			a = parseFlagToName(a)
 			// debugPrint("Arg", i, "is flag with value:", a)
+			a = parseFlagToName(a)
 			// parse flag into key and value and apply to subcommand flags
 			key, val := parseArgWithValue(a)
 			_, err = setValueForParsers(key, val, p, sc)
@@ -211,7 +211,7 @@ func (sc *Subcommand) parse(p *Parser, args []string, depth int) error {
 		// the first relative positional argument will be human natural at position 1
 		// but offset for the depth of relative commands being parsed for currently.
 		relativeDepth := pos - depth + 1
-		debugPrint("Parsing positional only position", relativeDepth, "with value", v)
+		// debugPrint("Parsing positional only position", relativeDepth, "with value", v)
 
 		if relativeDepth < 1 {
 			debugPrint("skipped value", v)
@@ -220,7 +220,7 @@ func (sc *Subcommand) parse(p *Parser, args []string, depth int) error {
 		parsedArgCount++
 		// determine subcommands and parse them by positional value and name
 		for _, cmd := range sc.Subcommands {
-			debugPrint("Subcommand being compared", relativeDepth, "==", cmd.Position, "and", v, "==", cmd.Name, "==", cmd.ShortName)
+			// debugPrint("Subcommand being compared", relativeDepth, "==", cmd.Position, "and", v, "==", cmd.Name, "==", cmd.ShortName)
 			if relativeDepth == cmd.Position && (v == cmd.Name || v == cmd.ShortName) {
 				debugPrint("Decending into positional subcommand", cmd.Name, "at relativeDepth", relativeDepth, "and absolute depth", depth+1)
 				return cmd.parse(p, args, depth+parsedArgCount) // continue recursive positional parsing
@@ -234,7 +234,7 @@ func (sc *Subcommand) parse(p *Parser, args []string, depth int) error {
 				debugPrint("Found a positional value at relativePos:", relativeDepth, "value:", v)
 				// defrerence the struct pointer, then set the pointer property within it
 				*val.AssignmentVar = v
-				debugPrint("set positional to value", *val.AssignmentVar)
+				// debugPrint("set positional to value", *val.AssignmentVar)
 				foundPositional = true
 				val.Found = true
 				break

--- a/subCommand.go
+++ b/subCommand.go
@@ -345,7 +345,6 @@ func (sc *Subcommand) AddSubcommand(newSC *Subcommand, relativePosition int) err
 	return nil
 }
 
-<<<<<<< HEAD
 // addFlag is a generic to add flags of any type
 func (sc *Subcommand) addFlag(assignmentVar interface{}, shortName string, longName string, description string) error {
 
@@ -558,33 +557,17 @@ func (sc *Subcommand) AddHardwareAddrFlag(assignmentVar *net.HardwareAddr, short
 // AddHardwareAddrSliceFlag adds a new net.HardwareAddr slice flag.
 // Specify the flag multiple times to fill the slice.
 func (sc *Subcommand) AddHardwareAddrSliceFlag(assignmentVar *[]net.HardwareAddr, shortName string, longName string, description string) error {
-=======
-// addFlag genericly adds flags to a subcommand
-func (sc *Subcommand) addFlag(assignmentVar *interface{}, shortName string, longName string, description string) error {
-	// if the flag is already used, throw an error
-	for _, existingFlag := range sc.Flags {
-		if longName != "" && existingFlag.LongName == longName {
-			return errors.New("Flag " + longName + " added to subcommand " + sc.Name + " but it is already assigned.")
-		}
-		if shortName != "" && existingFlag.ShortName == shortName {
-			return errors.New("Flag " + shortName + " added to subcommand " + sc.Name + " but it is already assigned.")
-		}
-	}
-
-	newFlag := Flag{}
-	newFlag.AssignmentVar = assignmentVar
-	newFlag.ShortName = shortName
-	newFlag.LongName = longName
-	newFlag.Description = description
-
-	sc.Flags = append(sc.Flags, &newFlag)
-	return nil
+	return sc.addFlag(assignmentVar, shortName, longName, description)
 }
 
-// AddDurationFlag flag adds a new duration flag to the parser
-func (sc *Subcommand) AddDurationFlag(assignmentVar *time.Duration, shortName string, longName string, description string) error {
+// AddIPMaskFlag adds a new net.IPMask flag. IPv4 Only.
+func (sc *Subcommand) AddIPMaskFlag(assignmentVar *net.IPMask, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
 
->>>>>>> 541280e04e9ff40f32fe78b58bc7f94a5bb0042b
+// AddIPMaskSliceFlag adds a new net.HardwareAddr slice flag. IPv4 only.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddIPMaskSliceFlag(assignmentVar *[]net.IPMask, shortName string, longName string, description string) error {
 	return sc.addFlag(assignmentVar, shortName, longName, description)
 }
 

--- a/subCommand.go
+++ b/subCommand.go
@@ -198,6 +198,7 @@ func (sc *Subcommand) parse(p *Parser, args []string, depth int) error {
 
 	// Parse the normal flags out of the argument list and retain the positionals.
 	// Apply the flags to the parent parser and the current subcommand context.
+	// ./command -f -z subcommand someVar -b becomes ./command subcommand somevar
 	positionalOnlyArguments, helpRequested, err := sc.parseAllFlagsFromArgs(p, args)
 	if err != nil {
 		return err
@@ -215,10 +216,11 @@ func (sc *Subcommand) parse(p *Parser, args []string, depth int) error {
 		// debugPrint("Parsing positional only position", relativeDepth, "with value", v)
 
 		if relativeDepth < 1 {
-			debugPrint("skipped value", v)
+			debugPrint(sc.Name, "skipped value:", v)
 			continue
 		}
 		parsedArgCount++
+
 		// determine subcommands and parse them by positional value and name
 		for _, cmd := range sc.Subcommands {
 			// debugPrint("Subcommand being compared", relativeDepth, "==", cmd.Position, "and", v, "==", cmd.Name, "==", cmd.ShortName)
@@ -359,11 +361,12 @@ func (sc *Subcommand) addFlag(assignmentVar interface{}, shortName string, longN
 		}
 	}
 
-	newFlag := Flag{}
-	newFlag.AssignmentVar = assignmentVar
-	newFlag.ShortName = shortName
-	newFlag.LongName = longName
-	newFlag.Description = description
+	newFlag := Flag{
+		AssignmentVar: assignmentVar,
+		ShortName:     shortName,
+		LongName:      longName,
+		Description:   description,
+	}
 	sc.Flags = append(sc.Flags, &newFlag)
 
 	return nil

--- a/subCommand.go
+++ b/subCommand.go
@@ -20,10 +20,7 @@ type Subcommand struct {
 	Description           string
 	Position              int // the position of this subcommand, not including flags
 	Subcommands           []*Subcommand
-	StringFlags           []*StringFlag
-	IntFlags              []*IntFlag
-	BoolFlags             []*BoolFlag
-	DurationFlags         []*DurationFlag
+	Flags                 []*Flag
 	PositionalFlags       []*PositionalValue
 	AdditionalHelpPrepend string             // additional prepended message when Help is displayed
 	AdditionalHelpAppend  string             // additional appended message when Help is displayed
@@ -304,19 +301,7 @@ func (sc *Subcommand) parse(p *Parser, args []string, depth int) error {
 // name in the (sub)command
 func (sc *Subcommand) FlagExists(name string) bool {
 
-	for _, f := range sc.StringFlags {
-		if f.HasName(name) {
-			return true
-		}
-	}
-
-	for _, f := range sc.IntFlags {
-		if f.HasName(name) {
-			return true
-		}
-	}
-
-	for _, f := range sc.BoolFlags {
+	for _, f := range sc.Flags {
 		if f.HasName(name) {
 			return true
 		}
@@ -484,8 +469,8 @@ func (sc *Subcommand) SetValueForKey(key string, value string) (bool, error) {
 
 	// debugPrint("Looking to set key", key, "to value", value)
 
-	// check for and assign string flags
-	for _, f := range sc.StringFlags {
+	// check for and assign flags
+	for _, f := range sc.Flags {
 		// debugPrint("Evaluating string flag", f.ShortName, "==", key, "||", f.LongName, "==", key)
 		if f.ShortName == key || f.LongName == key {
 			// debugPrint("Setting string value for", key, "to", value)

--- a/subCommand.go
+++ b/subCommand.go
@@ -3,6 +3,7 @@ package flaggy
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"text/template"
@@ -367,13 +368,14 @@ func (sc *Subcommand) addFlag(assignmentVar interface{}, shortName string, longN
 	return nil
 }
 
-// AddDurationFlag flag adds a new duration flag to the parser
-func (sc *Subcommand) AddDurationFlag(assignmentVar *time.Duration, shortName string, longName string, description string) error {
+// AddStringFlag adds a new string flag
+func (sc *Subcommand) AddStringFlag(assignmentVar *string, shortName string, longName string, description string) error {
 	return sc.addFlag(assignmentVar, shortName, longName, description)
 }
 
-// AddStringFlag adds a new string flag
-func (sc *Subcommand) AddStringFlag(assignmentVar *string, shortName string, longName string, description string) error {
+// AddStringSliceFlag adds a new slice of strings flag
+// Specify the flag multiple times to fill the slice
+func (sc *Subcommand) AddStringSliceFlag(assignmentVar *[]string, shortName string, longName string, description string) error {
 	return sc.addFlag(assignmentVar, shortName, longName, description)
 }
 
@@ -382,8 +384,179 @@ func (sc *Subcommand) AddBoolFlag(assignmentVar *bool, shortName string, longNam
 	return sc.addFlag(assignmentVar, shortName, longName, description)
 }
 
+// AddBoolSliceFlag adds a new slice of bools flag
+// Specify the flag multiple times to fill the slice
+func (sc *Subcommand) AddBoolSliceFlag(assignmentVar *[]bool, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddByteSliceFlag adds a new slice of bytes flag
+// Specify the flag multiple times to fill the slice.  Takes hex as input.
+func (sc *Subcommand) AddByteSliceFlag(assignmentVar *[]byte, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddDurationFlag adds a new time.Duration flag.
+// Input format is described in time.ParseDuration().
+// Example values: 1h, 1h50m, 32s
+func (sc *Subcommand) AddDurationFlag(assignmentVar *time.Duration, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddDurationSliceFlag adds a new time.Duration flag.
+// Input format is described in time.ParseDuration().
+// Example values: 1h, 1h50m, 32s
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddDurationSliceFlag(assignmentVar *[]time.Duration, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddFloat32Flag adds a new float32 flag.
+func (sc *Subcommand) AddFloat32Flag(assignmentVar *float32, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddFloat32SliceFlag adds a new float32 flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddFloat32SliceFlag(assignmentVar *[]float32, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddFloat64Flag adds a new float64 flag.
+func (sc *Subcommand) AddFloat64Flag(assignmentVar *float64, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddFloat64SliceFlag adds a new float64 flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddFloat64SliceFlag(assignmentVar *[]float64, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
 // AddIntFlag adds a new int flag
 func (sc *Subcommand) AddIntFlag(assignmentVar *int, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddIntSliceFlag adds a new int slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddIntSliceFlag(assignmentVar *[]int, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUIntFlag adds a new uint flag
+func (sc *Subcommand) AddUIntFlag(assignmentVar *uint, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUIntSliceFlag adds a new uint slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddUIntSliceFlag(assignmentVar *[]uint, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt64Flag adds a new uint64 flag
+func (sc *Subcommand) AddUInt64Flag(assignmentVar *uint64, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt64SliceFlag adds a new uint64 slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddUInt64SliceFlag(assignmentVar *[]uint64, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt32Flag adds a new uint32 flag
+func (sc *Subcommand) AddUInt32Flag(assignmentVar *uint32, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt32SliceFlag adds a new uint32 slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddUInt32SliceFlag(assignmentVar *[]uint32, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt16Flag adds a new uint16 flag
+func (sc *Subcommand) AddUInt16Flag(assignmentVar *uint16, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt16SliceFlag adds a new uint16 slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddUInt16SliceFlag(assignmentVar *[]uint16, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt8Flag adds a new uint8 flag
+func (sc *Subcommand) AddUInt8Flag(assignmentVar *uint8, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddUInt8SliceFlag adds a new uint8 slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddUInt8SliceFlag(assignmentVar *[]uint8, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt64SliceFlag adds a new int64 slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddInt64SliceFlag(assignmentVar *[]int64, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt32Flag adds a new int32 flag
+func (sc *Subcommand) AddInt32Flag(assignmentVar *int32, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt32SliceFlag adds a new int32 slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddInt32SliceFlag(assignmentVar *[]int32, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt16Flag adds a new int16 flag
+func (sc *Subcommand) AddInt16Flag(assignmentVar *int16, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt16SliceFlag adds a new int16 slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddInt16SliceFlag(assignmentVar *[]int16, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt8Flag adds a new int8 flag
+func (sc *Subcommand) AddInt8Flag(assignmentVar *int8, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddInt8SliceFlag adds a new int8 slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddInt8SliceFlag(assignmentVar *[]int8, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddIPFlag adds a new net.IP flag.
+func (sc *Subcommand) AddIPFlag(assignmentVar *net.IP, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddIPSliceFlag adds a new int8 slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddIPSliceFlag(assignmentVar *[]net.IP, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddHardwareAddrFlag adds a new net.HardwareAddr flag.
+func (sc *Subcommand) AddHardwareAddrFlag(assignmentVar *net.HardwareAddr, shortName string, longName string, description string) error {
+	return sc.addFlag(assignmentVar, shortName, longName, description)
+}
+
+// AddHardwareAddrSliceFlag adds a new net.HardwareAddr slice flag.
+// Specify the flag multiple times to fill the slice.
+func (sc *Subcommand) AddHardwareAddrSliceFlag(assignmentVar *[]net.HardwareAddr, shortName string, longName string, description string) error {
 	return sc.addFlag(assignmentVar, shortName, longName, description)
 }
 

--- a/subCommand.go
+++ b/subCommand.go
@@ -190,6 +190,7 @@ func (sc *Subcommand) parseAllFlagsFromArgs(p *Parser, args []string) ([]string,
 // Parse causes the argument parser to parse based on the supplied []string.
 // depth specifies the non-flag subcommand positional depth
 func (sc *Subcommand) parse(p *Parser, args []string, depth int) error {
+
 	debugPrint("- Parsing subcommand", sc.Name, "with depth of", depth, "and args", args)
 
 	// if a command is parsed, its used


### PR DESCRIPTION
This is a major refactor to the flag parser to enable multiple-use flags #3 and a generic flag parser backed by a type switch for specific conversions #7.

In addition, flaggy now supports 35 different flag types!

```
string
[]string
bool
[]bool
time.Duration
[]time.Duration
float32
[]float32
float64
[]float64
uint
uint64
[]uint64
uint32
[]uint32
uint16
[]uint16
uint8
[]uint8
[]byte
int
[]int
int64
[]int64
int32
[]int32
int16
[]int16
int8
[]int8
net.IP
[]net.IP
net.HardwareAddr
[]net.HardwareAddr
net.IPMask
[]net.IPMask
```