### PR TITLE
Rename public functions to simpler verions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ net.IPMask
 // Declare variables and their defaults
 var stringFlag = "defaultValue"
 
-// Add a flag
-flaggy.AddStringFlag(&stringFlag, "f", "flag", "A test string flag")
+//  a flag
+flaggy.String(&stringFlag, "f", "flag", "A test string flag")
 
 // Parse the flag
 flaggy.Parse()
@@ -140,11 +140,11 @@ var stringFlag = "defaultValue"
 // Create the subcommand
 subcommand := flaggy.NewSubcommand("subcommandExample")
 
-// Add a flag to the subcommand
-subcommand.AddStringFlag(&stringFlag, "f", "flag", "A test string flag")
+//  a flag to the subcommand
+subcommand.String(&stringFlag, "f", "flag", "A test string flag")
 
-// Add the subcommand to the parser at position 1
-flaggy.AddSubcommand(subcommand, 1)
+//  the subcommand to the parser at position 1
+flaggy.AttachSubcommand(subcommand, 1)
 
 // Parse the subcommand and all flags
 flaggy.Parse()
@@ -167,18 +167,18 @@ var boolFlagB bool
 subcommandExample := flaggy.NewSubcommand("subcommandExample")
 nestedSubcommand := flaggy.NewSubcommand("nestedSubcommand")
 
-// Add a flag to the subcommand
-subcommandExample.AddStringFlag(&stringFlagF, "t", "testFlag", "A test string flag")
+//  a flag to the subcommand
+subcommandExample.String(&stringFlagF, "t", "testFlag", "A test string flag")
 
-nestedSubcommand.AddIntFlag(&intFlagT, "f", "flag", "A test int flag")
+nestedSubcommand.Int(&intFlagT, "f", "flag", "A test int flag")
 
 // add a global bool flag for fun
-flaggy.AddBoolFlag(&boolFlagB, "y", "yes", "A sample boolean flag")
+flaggy.Bool(&boolFlagB, "y", "yes", "A sample boolean flag")
 
-// Add the nested subcommand to the parent subcommand at position 1
-subcommandExample.AddSubcommand(nestedSubcommand, 1)
-// Add the base subcommand to the parser at position 1
-flaggy.AddSubcommand(subcommandExample, 1)
+//  the nested subcommand to the parent subcommand at position 1
+subcommandExample.AttachSubcommand(nestedSubcommand, 1)
+//  the base subcommand to the parser at position 1
+flaggy.AttachSubcommand(subcommandExample, 1)
 
 // Parse the subcommand and all flags
 flaggy.Parse()

--- a/examples/complex/main.go
+++ b/examples/complex/main.go
@@ -13,18 +13,18 @@ func main() {
 	subcommandExample := flaggy.NewSubcommand("subcommandExample")
 	nestedSubcommand := flaggy.NewSubcommand("nestedSubcommand")
 
-	// Add a flag to the subcommand
-	subcommandExample.AddStringFlag(&stringFlagF, "t", "testFlag", "A test string flag")
-	nestedSubcommand.AddIntFlag(&intFlagT, "f", "flag", "A test int flag")
+	//  a flag to the subcommand
+	subcommandExample.String(&stringFlagF, "t", "testFlag", "A test string flag")
+	nestedSubcommand.Int(&intFlagT, "f", "flag", "A test int flag")
 
 	// add a global bool flag for fun
-	flaggy.AddBoolFlag(&boolFlagB, "y", "yes", "A sample boolean flag")
+	flaggy.Bool(&boolFlagB, "y", "yes", "A sample boolean flag")
 
-	// Add the nested subcommand to the parent subcommand at position 1
-	subcommandExample.AddSubcommand(nestedSubcommand, 1)
+	//  the nested subcommand to the parent subcommand at position 1
+	subcommandExample.AttachSubcommand(nestedSubcommand, 1)
 
-	// Add the base subcommand to the parser at position 1
-	flaggy.AddSubcommand(subcommandExample, 1)
+	//  the base subcommand to the parser at position 1
+	flaggy.AttachSubcommand(subcommandExample, 1)
 
 	// Parse the subcommand and all flags
 	flaggy.Parse()

--- a/examples/customParser/main.go
+++ b/examples/customParser/main.go
@@ -28,13 +28,13 @@ func main() {
 	// you don't have to finish the subcommand before adding it to the parser
 	subCmd := flaggy.NewSubcommand("subCmd")
 	subCmd.Description = "Description of subcommand"
-	p.AddSubcommand(subCmd, 2)
+	p.AttachSubcommand(subCmd, 2)
 
 	// add a flag to the subcomand
-	subCmd.AddIntFlag(&intFlagT, "i", "testInt", "This is a test int flag")
+	subCmd.Int(&intFlagT, "i", "testInt", "This is a test int flag")
 
 	// add a bool flag to the root command
-	p.AddBoolFlag(&boolFlagB, "b", "boolTest", "This is a test boolean flag")
+	p.Bool(&boolFlagB, "b", "boolTest", "This is a test boolean flag")
 
 	p.Parse()
 

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -6,8 +6,8 @@ func main() {
 	// Declare variables and their defaults
 	var stringFlag = "defaultValue"
 
-	// Add a flag
-	flaggy.AddStringFlag(&stringFlag, "f", "flag", "A test string flag")
+	//  a flag
+	flaggy.String(&stringFlag, "f", "flag", "A test string flag")
 
 	// Parse the flag
 	flaggy.Parse()

--- a/examples/subcommand/main.go
+++ b/examples/subcommand/main.go
@@ -9,11 +9,11 @@ func main() {
 	// Create the subcommand
 	subcommand := flaggy.NewSubcommand("subcommandExample")
 
-	// Add a flag to the subcommand
-	subcommand.AddStringFlag(&stringFlag, "f", "flag", "A test string flag")
+	//  a flag to the subcommand
+	subcommand.String(&stringFlag, "f", "flag", "A test string flag")
 
-	// Add the subcommand to the parser at position 1
-	flaggy.AddSubcommand(subcommand, 1)
+	//  the subcommand to the parser at position 1
+	flaggy.AttachSubcommand(subcommand, 1)
 
 	// Parse the subcommand and all flags
 	flaggy.Parse()

--- a/examples_test.go
+++ b/examples_test.go
@@ -27,7 +27,7 @@ func ExampleSubcommand_AddPositionalValue() {
 	// create a subcommand
 	subcommandA := flaggy.NewSubcommand("subcommandA")
 	// add the subcommand at relative position 1 within the default root parser
-	err = flaggy.AddSubcommand(subcommandA, 1)
+	err = flaggy.AttachSubcommand(subcommandA, 1)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func ExampleSubcommand_AddPositionalValue() {
 	subcommandB := flaggy.NewSubcommand("subcommandB")
 	// add the second subcommand to the first subcommand as a child at relative
 	// position 1
-	err = subcommandA.AddSubcommand(subcommandB, 1)
+	err = subcommandA.AttachSubcommand(subcommandB, 1)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -57,9 +57,9 @@ func ExampleSubcommand_AddPositionalValue() {
 	// Output: Positional flag set to subcommandBPositionalValue
 }
 
-// ExampleAddPositionalValue shows how to add positional variables at the
+// ExamplePositionalValue shows how to add positional variables at the
 // global level.
-func ExampleAddPositionalValue() {
+func ExamplePositionalValue() {
 
 	// Simulate some input from the CLI.  Don't do this in your program.
 	flaggy.ResetParser()
@@ -83,10 +83,10 @@ func ExampleAddPositionalValue() {
 	// Output: Flag set to positionalValue
 }
 
-// ExampleAddBoolFlag shows how to global bool flags in your program.
-func ExampleAddBoolFlag() {
+// ExampleBoolFlag shows how to global bool flags in your program.
+func ExampleBool() {
 
-	// Simulate some input from the CLI.  Don't do this in your program.
+	// Simulate some input from the CLI.  Don't do these two lines in your program.
 	flaggy.ResetParser()
 	os.Args = []string{"binaryName", "-f"}
 
@@ -98,7 +98,7 @@ func ExampleAddBoolFlag() {
 
 	// add a bool flag at the global level
 	var boolFlag bool
-	flaggy.AddBoolFlag(&boolFlag, "f", "flag", "A test bool flag")
+	flaggy.Bool(&boolFlag, "f", "flag", "A test bool flag")
 
 	// Parse the input arguments from the OS (os.Args)
 	flaggy.Parse()
@@ -110,8 +110,8 @@ func ExampleAddBoolFlag() {
 	// Output: Flag set
 }
 
-// ExampleAddIntFlag shows how to global int flags in your program.
-func ExampleAddIntFlag() {
+// ExampleIntFlag shows how to global int flags in your program.
+func ExampleInt() {
 
 	// Simulate some input from the CLI.  Don't do these two lines in your program.
 	flaggy.ResetParser()
@@ -125,7 +125,7 @@ func ExampleAddIntFlag() {
 
 	// add a int flag at the global level
 	var intFlag int
-	flaggy.AddIntFlag(&intFlag, "f", "flag", "A test int flag")
+	flaggy.Int(&intFlag, "f", "flag", "A test int flag")
 
 	// Parse the input arguments from the OS (os.Args)
 	flaggy.Parse()
@@ -137,8 +137,8 @@ func ExampleAddIntFlag() {
 	// Output: Flag set to: 5
 }
 
-// ExampleAddStringFlag shows how to global string flags in your program.
-func ExampleAddStringFlag() {
+// ExampleStringFlag shows how to global string flags in your program.
+func ExampleString() {
 
 	// Simulate some input from the CLI.  Don't do this in your program.
 	flaggy.ResetParser()
@@ -152,7 +152,7 @@ func ExampleAddStringFlag() {
 
 	// add a string flag at the global level
 	var stringFlag string
-	flaggy.AddStringFlag(&stringFlag, "f", "flag", "A test string flag")
+	flaggy.String(&stringFlag, "f", "flag", "A test string flag")
 
 	// Parse the input arguments from the OS (os.Args)
 	flaggy.Parse()
@@ -189,7 +189,7 @@ func Example() {
 
 	// Attach a string variable to the subcommand
 	var subcommandVariable string
-	newSC.AddStringFlag(&subcommandVariable, "v", "variable", "A test variable.")
+	newSC.String(&subcommandVariable, "v", "variable", "A test variable.")
 
 	var subcommandPositional string
 	newSC.AddPositionalValue(&subcommandPositional, "testPositionalVar", 1, false, "A test positional variable to a subcommand.")
@@ -197,7 +197,7 @@ func Example() {
 	// Attach the subcommand to the parser. This will error if another
 	// positional value or subcommand is already present at the depth supplied.
 	// Later you can check if this command was used with a simple bool.
-	err := flaggy.AddSubcommand(newSC, 1)
+	err := flaggy.AttachSubcommand(newSC, 1)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/flag.go
+++ b/flag.go
@@ -33,7 +33,7 @@ func (f *Flag) HasName(name string) bool {
 // the value is a type that needs parsing, that is performed as well.
 func (f *Flag) identifyAndAssignValue(value string) error {
 
-	fmt.Println("attempting to assign value", value, "to flag", f.LongName)
+	debugPrint("attempting to assign value", value, "to flag", f.LongName)
 
 	var err error
 
@@ -392,7 +392,7 @@ func parseFlagToName(arg string) string {
 // flagIsBool determines if the flag is a bool within the specified parser
 // and subcommand's context
 func flagIsBool(sc *Subcommand, p *Parser, key string) bool {
-	for _, f := range sc.Flags {
+	for _, f := range append(sc.Flags, p.Flags...) {
 		if f.HasName(key) {
 			_, isBool := f.AssignmentVar.(*bool)
 			_, isBoolSlice := f.AssignmentVar.(*[]bool)

--- a/flag_test.go
+++ b/flag_test.go
@@ -80,8 +80,8 @@ func TestInputParsing(t *testing.T) {
 
 	// Setup input arguments for every input type
 
-	var stringFlag string = "defaultVar"
-	err = AddStringFlag(&stringFlag, "s", "string", "string flag")
+	var stringFlag = "defaultVar"
+	err = String(&stringFlag, "s", "string", "string flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestInputParsing(t *testing.T) {
 	var stringFlagExpected = "flaggy"
 
 	var stringSliceFlag []string
-	err = AddStringSliceFlag(&stringSliceFlag, "ssf", "stringSlice", "string slice flag")
+	err = StringSlice(&stringSliceFlag, "ssf", "stringSlice", "string slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestInputParsing(t *testing.T) {
 	var stringSliceFlagExpected = []string{"one", "two"}
 
 	var boolFlag bool
-	err = AddBoolFlag(&boolFlag, "bf", "bool", "bool flag")
+	err = Bool(&boolFlag, "bf", "bool", "bool flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestInputParsing(t *testing.T) {
 	var boolFlagExpected = true
 
 	var boolSliceFlag []bool
-	err = AddBoolSliceFlag(&boolSliceFlag, "bsf", "boolSlice", "bool slice flag")
+	err = BoolSlice(&boolSliceFlag, "bsf", "boolSlice", "bool slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestInputParsing(t *testing.T) {
 	var boolSliceFlagExpected = []bool{true, true}
 
 	var byteSliceFlag []byte
-	err = AddByteSliceFlag(&byteSliceFlag, "bysf", "byteSlice", "byte slice flag")
+	err = ByteSlice(&byteSliceFlag, "bysf", "byteSlice", "byte slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestInputParsing(t *testing.T) {
 	var byteSliceFlagExpected = []uint8{17, 18}
 
 	var durationFlag time.Duration
-	err = AddDurationFlag(&durationFlag, "df", "duration", "duration flag")
+	err = Duration(&durationFlag, "df", "duration", "duration flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestInputParsing(t *testing.T) {
 	var durationFlagExpected = time.Second * 33
 
 	var durationSliceFlag []time.Duration
-	err = AddDurationSliceFlag(&durationSliceFlag, "dsf", "durationSlice", "duration slice flag")
+	err = DurationSlice(&durationSliceFlag, "dsf", "durationSlice", "duration slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestInputParsing(t *testing.T) {
 	var durationSliceFlagExpected = []time.Duration{time.Second * 33, time.Hour}
 
 	var float32Flag float32
-	err = AddFloat32Flag(&float32Flag, "f32", "float32", "float32 flag")
+	err = Float32(&float32Flag, "f32", "float32", "float32 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestInputParsing(t *testing.T) {
 	var float32FlagExpected float32 = 33.343
 
 	var float32SliceFlag []float32
-	err = AddFloat32SliceFlag(&float32SliceFlag, "f32s", "float32Slice", "float32 slice flag")
+	err = Float32Slice(&float32SliceFlag, "f32s", "float32Slice", "float32 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestInputParsing(t *testing.T) {
 	var float32SliceFlagExpected = []float32{33.343, 33.222}
 
 	var float64Flag float64
-	err = AddFloat64Flag(&float64Flag, "f64", "float64", "float64 flag")
+	err = Float64(&float64Flag, "f64", "float64", "float64 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestInputParsing(t *testing.T) {
 	var float64FlagExpected = 33.222343
 
 	var float64SliceFlag []float64
-	err = AddFloat64SliceFlag(&float64SliceFlag, "f64s", "float64Slice", "float64 slice flag")
+	err = Float64Slice(&float64SliceFlag, "f64s", "float64Slice", "float64 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestInputParsing(t *testing.T) {
 	var float64SliceFlagExpected = []float64{64.343, 64.222}
 
 	var intFlag int
-	err = AddIntFlag(&intFlag, "i", "int", "int flag")
+	err = Int(&intFlag, "i", "int", "int flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestInputParsing(t *testing.T) {
 	var intFlagExpected = 3553
 
 	var intSliceFlag []int
-	err = AddIntSliceFlag(&intSliceFlag, "is", "intSlice", "int slice flag")
+	err = IntSlice(&intSliceFlag, "is", "intSlice", "int slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +185,7 @@ func TestInputParsing(t *testing.T) {
 	var intSliceFlagExpected = []int{6446, 64}
 
 	var uintFlag uint
-	err = AddUIntFlag(&uintFlag, "ui", "uint", "uint flag")
+	err = UInt(&uintFlag, "ui", "uint", "uint flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func TestInputParsing(t *testing.T) {
 	var uintFlagExpected uint = 3553
 
 	var uintSliceFlag []uint
-	err = AddUIntSliceFlag(&uintSliceFlag, "uis", "uintSlice", "uint slice flag")
+	err = UIntSlice(&uintSliceFlag, "uis", "uintSlice", "uint slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestInputParsing(t *testing.T) {
 	var uintSliceFlagExpected = []uint{6446, 64}
 
 	var uint64Flag uint64
-	err = AddUInt64Flag(&uint64Flag, "ui64", "uint64", "uint64 flag")
+	err = UInt64(&uint64Flag, "ui64", "uint64", "uint64 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestInputParsing(t *testing.T) {
 	var uint64FlagExpected uint64 = 3553
 
 	var uint64SliceFlag []uint64
-	err = AddUInt64SliceFlag(&uint64SliceFlag, "ui64s", "uint64Slice", "uint64 slice flag")
+	err = UInt64Slice(&uint64SliceFlag, "ui64s", "uint64Slice", "uint64 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +217,7 @@ func TestInputParsing(t *testing.T) {
 	var uint64SliceFlagExpected = []uint64{6446, 64}
 
 	var uint32Flag uint32
-	err = AddUInt32Flag(&uint32Flag, "ui32", "uint32", "uint32 flag")
+	err = UInt32(&uint32Flag, "ui32", "uint32", "uint32 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestInputParsing(t *testing.T) {
 	var uint32FlagExpected uint32 = 6446
 
 	var uint32SliceFlag []uint32
-	err = AddUInt32SliceFlag(&uint32SliceFlag, "ui32s", "uint32Slice", "uint32 slice flag")
+	err = UInt32Slice(&uint32SliceFlag, "ui32s", "uint32Slice", "uint32 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +233,7 @@ func TestInputParsing(t *testing.T) {
 	var uint32SliceFlagExpected = []uint32{6446, 64}
 
 	var uint16Flag uint16
-	err = AddUInt16Flag(&uint16Flag, "ui16", "uint16", "uint16 flag")
+	err = UInt16(&uint16Flag, "ui16", "uint16", "uint16 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestInputParsing(t *testing.T) {
 	var uint16FlagExpected uint16 = 6446
 
 	var uint16SliceFlag []uint16
-	err = AddUInt16SliceFlag(&uint16SliceFlag, "ui16s", "uint16Slice", "uint16 slice flag")
+	err = UInt16Slice(&uint16SliceFlag, "ui16s", "uint16Slice", "uint16 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func TestInputParsing(t *testing.T) {
 	var uint16SliceFlagExpected = []uint16{6446, 64}
 
 	var uint8Flag uint8
-	err = AddUInt8Flag(&uint8Flag, "ui8", "uint8", "uint8 flag")
+	err = UInt8(&uint8Flag, "ui8", "uint8", "uint8 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestInputParsing(t *testing.T) {
 	var uint8FlagExpected uint8 = 50
 
 	var uint8SliceFlag []uint8
-	err = AddUInt8SliceFlag(&uint8SliceFlag, "ui8s", "uint8Slice", "uint8 slice flag")
+	err = UInt8Slice(&uint8SliceFlag, "ui8s", "uint8Slice", "uint8 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +265,7 @@ func TestInputParsing(t *testing.T) {
 	var uint8SliceFlagExpected = []uint8{uint8(3), uint8(2)}
 
 	var int64Flag int64
-	err = AddInt64Flag(&int64Flag, "i64", "i64", "int64 flag")
+	err = Int64(&int64Flag, "i64", "i64", "int64 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +273,7 @@ func TestInputParsing(t *testing.T) {
 	var int64FlagExpected int64 = 33445566
 
 	var int64SliceFlag []int64
-	err = AddInt64SliceFlag(&int64SliceFlag, "i64s", "int64Slice", "int64 slice flag")
+	err = Int64Slice(&int64SliceFlag, "i64s", "int64Slice", "int64 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ func TestInputParsing(t *testing.T) {
 	var int64SliceFlagExpected = []int64{40, 50}
 
 	var int32Flag int32
-	err = AddInt32Flag(&int32Flag, "i32", "int32", "int32 flag")
+	err = Int32(&int32Flag, "i32", "int32", "int32 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +289,7 @@ func TestInputParsing(t *testing.T) {
 	var int32FlagExpected int32 = 445566
 
 	var int32SliceFlag []int32
-	err = AddInt32SliceFlag(&int32SliceFlag, "i32s", "int32Slice", "uint32 slice flag")
+	err = Int32Slice(&int32SliceFlag, "i32s", "int32Slice", "uint32 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +297,7 @@ func TestInputParsing(t *testing.T) {
 	var int32SliceFlagExpected = []int32{40, 50}
 
 	var int16Flag int16
-	err = AddInt16Flag(&int16Flag, "i16", "int16", "int16 flag")
+	err = Int16(&int16Flag, "i16", "int16", "int16 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +305,7 @@ func TestInputParsing(t *testing.T) {
 	var int16FlagExpected int16 = 5566
 
 	var int16SliceFlag []int16
-	err = AddInt16SliceFlag(&int16SliceFlag, "i16s", "int16Slice", "int16 slice flag")
+	err = Int16Slice(&int16SliceFlag, "i16s", "int16Slice", "int16 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func TestInputParsing(t *testing.T) {
 	var int16SliceFlagExpected = []int16{40, 50}
 
 	var int8Flag int8
-	err = AddInt8Flag(&int8Flag, "i8", "int8", "int8 flag")
+	err = Int8(&int8Flag, "i8", "int8", "int8 flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestInputParsing(t *testing.T) {
 	var int8FlagExpected int8 = 32
 
 	var int8SliceFlag []int8
-	err = AddInt8SliceFlag(&int8SliceFlag, "i8s", "int8Slice", "uint8 slice flag")
+	err = Int8Slice(&int8SliceFlag, "i8s", "int8Slice", "uint8 slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ func TestInputParsing(t *testing.T) {
 	var int8SliceFlagExpected = []int8{4, 2}
 
 	var ipFlag net.IP
-	err = AddIPFlag(&ipFlag, "ip", "ipFlag", "ip flag")
+	err = IP(&ipFlag, "ip", "ipFlag", "ip flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +337,7 @@ func TestInputParsing(t *testing.T) {
 	var ipFlagExpected = net.IPv4(1, 1, 1, 1)
 
 	var ipSliceFlag []net.IP
-	err = AddIPSliceFlag(&ipSliceFlag, "ips", "ipFlagSlice", "ip slice flag")
+	err = IPSlice(&ipSliceFlag, "ips", "ipFlagSlice", "ip slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,7 +345,7 @@ func TestInputParsing(t *testing.T) {
 	var ipSliceFlagExpected = []net.IP{net.IPv4(1, 1, 1, 1), net.IPv4(4, 4, 4, 4)}
 
 	var hwFlag net.HardwareAddr
-	err = AddHardwareAddrFlag(&hwFlag, "hw", "hwFlag", "hw flag")
+	err = HardwareAddr(&hwFlag, "hw", "hwFlag", "hw flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +356,7 @@ func TestInputParsing(t *testing.T) {
 	}
 
 	var hwFlagSlice []net.HardwareAddr
-	err = AddHardwareAddrSliceFlag(&hwFlagSlice, "hws", "hwFlagSlice", "hw slice flag")
+	err = HardwareAddrSlice(&hwFlagSlice, "hws", "hwFlagSlice", "hw slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -372,7 +372,7 @@ func TestInputParsing(t *testing.T) {
 	var hwFlagSliceExpected = []net.HardwareAddr{macA, macB}
 
 	var maskFlag net.IPMask
-	err = AddIPMaskFlag(&maskFlag, "m", "mFlag", "mask flag")
+	err = IPMask(&maskFlag, "m", "mFlag", "mask flag")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,7 +380,7 @@ func TestInputParsing(t *testing.T) {
 	var maskFlagExpected = net.IPMask([]byte{255, 255, 255, 255})
 
 	var maskSliceFlag []net.IPMask
-	err = AddIPMaskSliceFlag(&maskSliceFlag, "ms", "mFlagSlice", "mask slice flag")
+	err = IPMaskSlice(&maskSliceFlag, "ms", "mFlagSlice", "mask slice flag")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/flaggy_test.go
+++ b/flaggy_test.go
@@ -9,6 +9,9 @@ import (
 // TestComplexNesting tests various levels of nested subcommands and
 // positional values intermixed with eachother.
 func TestComplexNesting(t *testing.T) {
+
+	flaggy.ResetParser()
+
 	var testA string
 	var testB string
 	var testC string
@@ -21,52 +24,61 @@ func TestComplexNesting(t *testing.T) {
 	scC := flaggy.NewSubcommand("scC")
 	scD := flaggy.NewSubcommand("scD")
 
-	flaggy.AddBoolFlag(&testF, "f", "testF", "")
+	flaggy.Bool(&testF, "f", "testF", "")
 
 	scA.AddPositionalValue(&testA, "testA", 1, false, "")
 	scA.AddPositionalValue(&testB, "testB", 2, false, "")
 	scA.AddPositionalValue(&testC, "testC", 3, false, "")
-	scA.AddSubcommand(scB, 4)
-	flaggy.AddSubcommand(scA, 1)
+	scA.AttachSubcommand(scB, 4)
+	flaggy.AttachSubcommand(scA, 1)
 
 	scB.AddPositionalValue(&testD, "testD", 1, false, "")
-	scB.AddSubcommand(scC, 2)
+	scB.AttachSubcommand(scC, 2)
 
-	scC.AddSubcommand(scD, 1)
+	scC.AttachSubcommand(scD, 1)
 
 	scD.AddPositionalValue(&testE, "testE", 1, true, "")
 
-	flaggy.ParseArgs([]string{"scA", "A", "-f", "B", "C", "scB", "D", "scC", "scD", "E"})
+	flaggy.ParseArgs([]string{"scA", "-f", "A", "B", "C", "scB", "D", "scC", "scD", "E"})
 
 	if !testF {
+		t.Log("testF", testF)
 		t.FailNow()
 	}
-
 	if !scA.Used {
+		t.Log("sca", scA.Name)
 		t.FailNow()
 	}
 	if !scB.Used {
+		t.Log("scb", scB.Name)
 		t.FailNow()
 	}
 	if !scC.Used {
+		t.Log("scc", scC.Name)
 		t.FailNow()
 	}
 	if !scD.Used {
+		t.Log("scd", scD.Name)
 		t.FailNow()
 	}
 	if testA != "A" {
+		t.Log("testA", testA)
 		t.FailNow()
 	}
 	if testB != "B" {
+		t.Log("testb", testB)
 		t.FailNow()
 	}
 	if testC != "C" {
+		t.Log("testC", testC)
 		t.FailNow()
 	}
 	if testD != "D" {
+		t.Log("testD", testD)
 		t.FailNow()
 	}
 	if testE != "E" {
+		t.Log("testE", testE)
 		t.FailNow()
 	}
 
@@ -88,33 +100,33 @@ func TestParsePositionalsA(t *testing.T) {
 	parser := flaggy.NewParser("testParser")
 
 	// add a bool flag to the parser
-	err = parser.AddBoolFlag(&boolT, "t", "", "test flag for bool arg")
+	err = parser.Bool(&boolT, "t", "", "test flag for bool arg")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// add an int flag to the parser
-	err = parser.AddIntFlag(&intT, "i", "", "test flag for int arg")
+	err = parser.Int(&intT, "i", "", "test flag for int arg")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// create a subcommand
 	subCommand := flaggy.NewSubcommand("subcommand")
-	err = parser.AddSubcommand(subCommand, 1)
+	err = parser.AttachSubcommand(subCommand, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// add flags to subcommand
-	err = subCommand.AddStringFlag(&testN, "n", "testN", "test flag for value with space arg")
+	err = subCommand.String(&testN, "n", "testN", "test flag for value with space arg")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = subCommand.AddStringFlag(&testJ, "j", "testJ", "test flag for value with equals arg")
+	err = subCommand.String(&testJ, "j", "testJ", "test flag for value with equals arg")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = subCommand.AddStringFlag(&testK, "k", "testK", "test full length flag with attached arg")
+	err = subCommand.String(&testK, "k", "testK", "test full length flag with attached arg")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helpValues_test.go
+++ b/helpValues_test.go
@@ -24,19 +24,19 @@ func TestHelpOutput(t *testing.T) {
 	scC.Description = "Subcommand C is a command that does SERIOUS stuff"
 	var posA string
 	var posB string
-	p.AddSubcommand(scA, 1)
-	p.AddSubcommand(scB, 1)
-	p.AddSubcommand(scC, 1)
+	p.AttachSubcommand(scA, 1)
+	p.AttachSubcommand(scB, 1)
+	p.AttachSubcommand(scC, 1)
 	p.AddPositionalValue(&posA, "testPositionalA", 2, true, "Test positional A does some things with a positional value.")
 	p.AddPositionalValue(&posB, "testPositionalB", 3, false, "Test positional B does some less than serious things with a positional value.")
 	var stringFlag string
 	var intFlag int
 	var boolFlag bool
 	var durationFlag time.Duration
-	p.AddStringFlag(&stringFlag, "s", "stringFlag", "This is a test string flag that does some stringy string stuff.")
-	p.AddIntFlag(&intFlag, "i", "intFlg", "This is a test int flag that does some interesting int stuff.")
-	p.AddBoolFlag(&boolFlag, "b", "boolFlag", "This is a test bool flag that does some booly bool stuff.")
-	p.AddDurationFlag(&durationFlag, "d", "durationFlag", "This is a test duration flag that does some untimely stuff.")
+	p.String(&stringFlag, "s", "stringFlag", "This is a test string flag that does some stringy string stuff.")
+	p.Int(&intFlag, "i", "intFlg", "This is a test int flag that does some interesting int stuff.")
+	p.Bool(&boolFlag, "b", "boolFlag", "This is a test bool flag that does some booly bool stuff.")
+	p.Duration(&durationFlag, "d", "durationFlag", "This is a test duration flag that does some untimely stuff.")
 	p.AdditionalHelpPrepend = "This is a prepend for help"
 	p.AdditionalHelpAppend = "This is an append for help"
 	p.ShowHelpWithMessage("This is a help addon message")

--- a/main.go
+++ b/main.go
@@ -86,217 +86,217 @@ func ParseArgs(args []string) error {
 	return err
 }
 
-// AddStringFlag adds a new string flag
-func AddStringFlag(assignmentVar *string, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// String adds a new string flag
+func String(assignmentVar *string, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddStringSliceFlag adds a new slice of strings flag
+// StringSlice adds a new slice of strings flag
 // Specify the flag multiple times to fill the slice
-func AddStringSliceFlag(assignmentVar *[]string, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func StringSlice(assignmentVar *[]string, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddBoolFlag adds a new bool flag
-func AddBoolFlag(assignmentVar *bool, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// Bool adds a new bool flag
+func Bool(assignmentVar *bool, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddBoolSliceFlag adds a new slice of bools flag
+// BoolSlice adds a new slice of bools flag
 // Specify the flag multiple times to fill the slice
-func AddBoolSliceFlag(assignmentVar *[]bool, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func BoolSlice(assignmentVar *[]bool, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddByteSliceFlag adds a new slice of bytes flag
+// ByteSlice adds a new slice of bytes flag
 // Specify the flag multiple times to fill the slice.  Takes hex as input.
-func AddByteSliceFlag(assignmentVar *[]byte, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func ByteSlice(assignmentVar *[]byte, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddDurationFlag adds a new time.Duration flag.
+// Duration adds a new time.Duration flag.
 // Input format is described in time.ParseDuration().
 // Example values: 1h, 1h50m, 32s
-func AddDurationFlag(assignmentVar *time.Duration, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func Duration(assignmentVar *time.Duration, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddDurationSliceFlag adds a new time.Duration flag.
+// DurationSlice adds a new time.Duration flag.
 // Input format is described in time.ParseDuration().
 // Example values: 1h, 1h50m, 32s
 // Specify the flag multiple times to fill the slice.
-func AddDurationSliceFlag(assignmentVar *[]time.Duration, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func DurationSlice(assignmentVar *[]time.Duration, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddFloat32Flag adds a new float32 flag.
-func AddFloat32Flag(assignmentVar *float32, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// Float32 adds a new float32 flag.
+func Float32(assignmentVar *float32, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddFloat32SliceFlag adds a new float32 flag.
+// Float32Slice adds a new float32 flag.
 // Specify the flag multiple times to fill the slice.
-func AddFloat32SliceFlag(assignmentVar *[]float32, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func Float32Slice(assignmentVar *[]float32, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddFloat64Flag adds a new float64 flag.
-func AddFloat64Flag(assignmentVar *float64, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// Float64 adds a new float64 flag.
+func Float64(assignmentVar *float64, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddFloat64SliceFlag adds a new float64 flag.
+// Float64Slice adds a new float64 flag.
 // Specify the flag multiple times to fill the slice.
-func AddFloat64SliceFlag(assignmentVar *[]float64, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func Float64Slice(assignmentVar *[]float64, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddIntFlag adds a new int flag
-func AddIntFlag(assignmentVar *int, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// Int adds a new int flag
+func Int(assignmentVar *int, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddIntSliceFlag adds a new int slice flag.
+// IntSlice adds a new int slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddIntSliceFlag(assignmentVar *[]int, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func IntSlice(assignmentVar *[]int, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUIntFlag adds a new uint flag
-func AddUIntFlag(assignmentVar *uint, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// UInt adds a new uint flag
+func UInt(assignmentVar *uint, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUIntSliceFlag adds a new uint slice flag.
+// UIntSlice adds a new uint slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddUIntSliceFlag(assignmentVar *[]uint, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func UIntSlice(assignmentVar *[]uint, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUInt64Flag adds a new uint64 flag
-func AddUInt64Flag(assignmentVar *uint64, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// UInt64 adds a new uint64 flag
+func UInt64(assignmentVar *uint64, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUInt64SliceFlag adds a new uint64 slice flag.
+// UInt64Slice adds a new uint64 slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddUInt64SliceFlag(assignmentVar *[]uint64, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func UInt64Slice(assignmentVar *[]uint64, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUInt32Flag adds a new uint32 flag
-func AddUInt32Flag(assignmentVar *uint32, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// UInt32 adds a new uint32 flag
+func UInt32(assignmentVar *uint32, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUInt32SliceFlag adds a new uint32 slice flag.
+// UInt32Slice adds a new uint32 slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddUInt32SliceFlag(assignmentVar *[]uint32, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func UInt32Slice(assignmentVar *[]uint32, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUInt16Flag adds a new uint16 flag
-func AddUInt16Flag(assignmentVar *uint16, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// UInt16 adds a new uint16 flag
+func UInt16(assignmentVar *uint16, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUInt16SliceFlag adds a new uint16 slice flag.
+// UInt16Slice adds a new uint16 slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddUInt16SliceFlag(assignmentVar *[]uint16, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func UInt16Slice(assignmentVar *[]uint16, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUInt8Flag adds a new uint8 flag
-func AddUInt8Flag(assignmentVar *uint8, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// UInt8 adds a new uint8 flag
+func UInt8(assignmentVar *uint8, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddUInt8SliceFlag adds a new uint8 slice flag.
+// UInt8Slice adds a new uint8 slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddUInt8SliceFlag(assignmentVar *[]uint8, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func UInt8Slice(assignmentVar *[]uint8, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddInt64Flag adds a new int64 flag
-func AddInt64Flag(assignmentVar *int64, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// Int64 adds a new int64 flag
+func Int64(assignmentVar *int64, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddInt64SliceFlag adds a new int64 slice flag.
+// Int64Slice adds a new int64 slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddInt64SliceFlag(assignmentVar *[]int64, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func Int64Slice(assignmentVar *[]int64, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddInt32Flag adds a new int32 flag
-func AddInt32Flag(assignmentVar *int32, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// Int32 adds a new int32 flag
+func Int32(assignmentVar *int32, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddInt32SliceFlag adds a new int32 slice flag.
+// Int32Slice adds a new int32 slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddInt32SliceFlag(assignmentVar *[]int32, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func Int32Slice(assignmentVar *[]int32, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddInt16Flag adds a new int16 flag
-func AddInt16Flag(assignmentVar *int16, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// Int16 adds a new int16 flag
+func Int16(assignmentVar *int16, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddInt16SliceFlag adds a new int16 slice flag.
+// Int16Slice adds a new int16 slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddInt16SliceFlag(assignmentVar *[]int16, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func Int16Slice(assignmentVar *[]int16, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddInt8Flag adds a new int8 flag
-func AddInt8Flag(assignmentVar *int8, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// Int8 adds a new int8 flag
+func Int8(assignmentVar *int8, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddInt8SliceFlag adds a new int8 slice flag.
+// Int8Slice adds a new int8 slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddInt8SliceFlag(assignmentVar *[]int8, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func Int8Slice(assignmentVar *[]int8, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddIPFlag adds a new net.IP flag.
-func AddIPFlag(assignmentVar *net.IP, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// IP adds a new net.IP flag.
+func IP(assignmentVar *net.IP, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddIPSliceFlag adds a new int8 slice flag.
+// IPSlice adds a new int8 slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddIPSliceFlag(assignmentVar *[]net.IP, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func IPSlice(assignmentVar *[]net.IP, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddHardwareAddrFlag adds a new net.HardwareAddr flag.
-func AddHardwareAddrFlag(assignmentVar *net.HardwareAddr, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// HardwareAddr adds a new net.HardwareAddr flag.
+func HardwareAddr(assignmentVar *net.HardwareAddr, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddHardwareAddrSliceFlag adds a new net.HardwareAddr slice flag.
+// HardwareAddrSlice adds a new net.HardwareAddr slice flag.
 // Specify the flag multiple times to fill the slice.
-func AddHardwareAddrSliceFlag(assignmentVar *[]net.HardwareAddr, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func HardwareAddrSlice(assignmentVar *[]net.HardwareAddr, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddIPMaskFlag adds a new net.IPMask flag. IPv4 Only.
-func AddIPMaskFlag(assignmentVar *net.IPMask, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+// IPMask adds a new net.IPMask flag. IPv4 Only.
+func IPMask(assignmentVar *net.IPMask, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddIPMaskSliceFlag adds a new net.HardwareAddr slice flag. IPv4 only.
+// IPMaskSlice adds a new net.HardwareAddr slice flag. IPv4 only.
 // Specify the flag multiple times to fill the slice.
-func AddIPMaskSliceFlag(assignmentVar *[]net.IPMask, shortName string, longName string, description string) error {
-	return mainParser.addFlag(assignmentVar, shortName, longName, description)
+func IPMaskSlice(assignmentVar *[]net.IPMask, shortName string, longName string, description string) error {
+	return mainParser.add(assignmentVar, shortName, longName, description)
 }
 
-// AddSubcommand adds a subcommand for parsing
-func AddSubcommand(newSC *Subcommand, relativePosition int) error {
-	return mainParser.AddSubcommand(newSC, relativePosition)
+// AttachSubcommand adds a subcommand for parsing
+func AttachSubcommand(newSC *Subcommand, relativePosition int) error {
+	return mainParser.AttachSubcommand(newSC, relativePosition)
 }
 
 // ShowHelp shows parser help

--- a/parser.go
+++ b/parser.go
@@ -57,7 +57,6 @@ func (p *Parser) Parse() error {
 	if err != nil {
 		return err
 	}
-	TrailingArguments = p.TrailingArguments
 	return nil
 
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,6 +3,8 @@ package flaggy
 import "testing"
 
 func TestDoubleParse(t *testing.T) {
+	ResetParser()
+
 	err := mainParser.Parse()
 	if err != nil {
 		t.Fatal(err)

--- a/subcommand_test.go
+++ b/subcommand_test.go
@@ -48,11 +48,11 @@ func TestTypoSubcommand(t *testing.T) {
 	args := []string{"unexpectedArg"}
 	newSCA := flaggy.NewSubcommand("TestTypoSubcommandA")
 	newSCB := flaggy.NewSubcommand("TestTypoSubcommandB")
-	err := p.AddSubcommand(newSCA, 1)
+	err := p.AttachSubcommand(newSCA, 1)
 	if err != nil {
 		t.Log(err)
 	}
-	err = p.AddSubcommand(newSCB, 1)
+	err = p.AttachSubcommand(newSCB, 1)
 	if err != nil {
 		t.Log(err)
 	}
@@ -117,7 +117,7 @@ func TestSubcommandParse(t *testing.T) {
 	newSC := flaggy.NewSubcommand("testSubcommand")
 
 	// add the subcommand into the parser
-	err := p.AddSubcommand(newSC, 1)
+	err := p.AttachSubcommand(newSC, 1)
 	if err != nil {
 		t.Fatal("Error adding subcommand", err)
 	}
@@ -151,7 +151,7 @@ func TestBadSubcommand(t *testing.T) {
 
 	// create a subcommand
 	newSC := flaggy.NewSubcommand("testSubcommand")
-	err := p.AddSubcommand(newSC, 1)
+	err := p.AttachSubcommand(newSC, 1)
 	if err != nil {
 		t.Fatal("Error adding subcommand", err)
 	}
@@ -188,14 +188,14 @@ func TestBadPositional(t *testing.T) {
 
 // TestNakedBoolFlag tests a naked boolean flag, which mean it has no
 // specified value beyond the flag being present.
-func TestNakedBoolFlag(t *testing.T) {
+func TestNakedBool(t *testing.T) {
 	flaggy.ResetParser()
 	os.Args = []string{"testBinary", "-t"}
 
 	// add a bool var
 	var boolVar bool
 	var err error
-	err = flaggy.AddBoolFlag(&boolVar, "t", "boolVar", "A boolean flag for testing")
+	err = flaggy.Bool(&boolVar, "t", "boolVar", "A boolean flag for testing")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Renaming all primary public functions to simpler format.  Fixed one bug along the way involving flags not being properly being identified as bool flags when the bool flag was assigned to the parser.

Example changes:

- `AddBoolFlag` is now just `Bool`
- `AddIntFlag` is now just `Int`
- `AddSubcommand` is now `AttachSubcommand`