### PR TITLE
Default flags in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,15 @@ This is a prepend for help
     subcommandC (c) - Subcommand C is a command that does SERIOUS stuff
 
   Flags:
+    -v --version  Displays the program version string.
+    -h --help  Displays help with available flag, subcommand, and positional value parameters.
     -s --stringFlag  This is a test string flag that does some stringy string stuff.
     -i --intFlg  This is a test int flag that does some interesting int stuff. (default: 5)
     -b --boolFlag  This is a test bool flag that does some booly bool stuff. (default: true)
     -d --durationFlag  This is a test duration flag that does some untimely stuff. (default: 1h23s)
 
 This is an append for help
-This is a help addon message
+This is a help add-on message
 ```
 
 # Supported Flag Types:

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,5 @@
+complex/complex
+customParser/customParser
+positionalValue/positionalValue
+simple/simple
+subcommand/subcommand

--- a/help.go
+++ b/help.go
@@ -3,22 +3,21 @@ package flaggy
 // defaultHelpTemplate is the help template used by default
 // {{if (or (or (gt (len .StringFlags) 0) (gt (len .IntFlags) 0)) (gt (len .BoolFlags) 0))}}
 // {{if (or (gt (len .StringFlags) 0) (gt (len .BoolFlags) 0))}}
-const defaultHelpTemplate = `{{.CommandName}}{{if .Description}} - {{.Description}}
-{{end}}{{if .PrependMessage}}{{.PrependMessage}}
-{{end}}{{if .UsageString}}
+const defaultHelpTemplate = `{{.CommandName}}{{if .Description}} - {{.Description}}{{end}}{{if .PrependMessage}}
+{{.PrependMessage}}{{end}}
+{{if .UsageString}}
   Usage:
     {{.UsageString}}{{end}}{{if .Positionals}}
 
   Positional Variables: {{range .Positionals}}
-    {{.Name}} -{{if .Required}} (Required){{end}}{{if .Description}} {{.Description}}{{end}}{{if .DefaultValue}} (default: {{.DefaultValue}}){{end}}{{end}}{{end}}{{if .Subcommands}}
+    {{.Name}}{{if .Required}} (Required){{end}}{{if .Description}} - {{.Description}}{{end}}{{if .DefaultValue}} (default: {{.DefaultValue}}){{end}}{{end}}{{end}}{{if .Subcommands}}
 
   Subcommands: {{range .Subcommands}}
-    {{.LongName}}{{if .ShortName}} ({{.ShortName}}){{end}} -{{if .Position}}{{if gt .Position 1}} (position {{.Position}}){{end}}{{end}}{{if .Description}} {{.Description}}{{end}}{{end}}
+    {{.LongName}}{{if .ShortName}} ({{.ShortName}}){{end}}{{if .Position}}{{if gt .Position 1}}  (position {{.Position}}){{end}}{{end}}{{if .Description}} - {{.Description}}{{end}}{{end}}
 {{end}}{{if (gt (len .Flags) 0)}}
   Flags: {{if .Flags}}{{range .Flags}}
     {{if .ShortName}}-{{.ShortName}} {{else}}   {{end}}{{if .LongName}}--{{.LongName}} {{end}}{{if .Description}} {{.Description}}{{if .DefaultValue}} (default: {{.DefaultValue}}){{end}}{{end}}{{end}}{{end}}
-{{end}}
-{{if .AppendMessage}}{{.AppendMessage}}
+{{end}}{{if .AppendMessage}}{{.AppendMessage}}
 {{end}}{{if .Message}}
-{{.Message}}
-{{end}}`
+{{.Message}}{{end}}
+`


### PR DESCRIPTION
- Fixes #20.  
- Moves methods for help to parsers, not subcommands
- Added concept of subcommand context
- Improvements to help template