### PR TITLE
Ineffectual version help flags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -355,7 +355,8 @@ func determineArgType(arg string) string {
 	return argIsPositional
 }
 
-// parseArgWithValue parses a key=value concatentated argument
+// parseArgWithValue parses a key=value concatentated argument into a key and
+// value
 func parseArgWithValue(arg string) (key string, value string) {
 
 	// remove up to two minuses from start of flag

--- a/flaggy_test.go
+++ b/flaggy_test.go
@@ -13,14 +13,16 @@ func TestTrailingArguments(t *testing.T) {
 	args := []string{"./flaggy.text", "--", "one", "two"}
 	os.Args = args
 	flaggy.Parse()
-	if len(flaggy.TrailingArguments) != len(args) {
-		t.Fatal("incorrect argument count parsed.  Got", len(flaggy.TrailingArguments), "but expected", len(args))
+	if len(flaggy.TrailingArguments) != 2 {
+		t.Fatal("incorrect argument count parsed.  Got", len(flaggy.TrailingArguments), "but expected", 2)
 	}
 
-	for i, _ := range args {
-		if args[i] != flaggy.TrailingArguments[i] {
-			t.Fatal("incorrect argument parsed.  Got", args[i], "but expected", flaggy.TrailingArguments[i])
-		}
+	if flaggy.TrailingArguments[0] != "one" {
+		t.Fatal("incorrect argument parsed.  Got", flaggy.TrailingArguments[0], "but expected one")
+	}
+
+	if flaggy.TrailingArguments[1] != "two" {
+		t.Fatal("incorrect argument parsed.  Got", flaggy.TrailingArguments[1], "but expected two")
 	}
 
 }

--- a/helpValues.go
+++ b/helpValues.go
@@ -50,16 +50,16 @@ func (h *Help) ExtractValues(p *Parser, message string) {
 
 	// extract Help values from the current subcommand in context
 	// prependMessage string
-	h.PrependMessage = p.subcommandInContext.AdditionalHelpPrepend
+	h.PrependMessage = p.subcommandContext.AdditionalHelpPrepend
 	// appendMessage  string
-	h.AppendMessage = p.subcommandInContext.AdditionalHelpAppend
+	h.AppendMessage = p.subcommandContext.AdditionalHelpAppend
 	// command name
-	h.CommandName = p.subcommandInContext.Name
+	h.CommandName = p.subcommandContext.Name
 	// description
-	h.Description = p.subcommandInContext.Description
+	h.Description = p.subcommandContext.Description
 
 	// subcommands    []HelpSubcommand
-	for _, cmd := range p.subcommandInContext.Subcommands {
+	for _, cmd := range p.subcommandContext.Subcommands {
 		if cmd.Hidden {
 			continue
 		}
@@ -73,7 +73,7 @@ func (h *Help) ExtractValues(p *Parser, message string) {
 	}
 
 	// parse positional flags into help output structs
-	for _, pos := range p.subcommandInContext.PositionalFlags {
+	for _, pos := range p.subcommandContext.PositionalFlags {
 		if pos.Hidden {
 			continue
 		}
@@ -110,7 +110,7 @@ func (h *Help) ExtractValues(p *Parser, message string) {
 	}
 
 	// go through every flag in the subcommand and list its options
-	for _, f := range p.subcommandInContext.Flags {
+	for _, f := range p.subcommandContext.Flags {
 		if f.Hidden {
 			continue
 		}
@@ -147,7 +147,7 @@ func (h *Help) ExtractValues(p *Parser, message string) {
 	// formulate the usage string
 	// first, we capture all the command and positional names by position
 	commandsByPosition := make(map[int]string)
-	for _, pos := range p.subcommandInContext.PositionalFlags {
+	for _, pos := range p.subcommandContext.PositionalFlags {
 		if pos.Hidden {
 			continue
 		}
@@ -157,7 +157,7 @@ func (h *Help) ExtractValues(p *Parser, message string) {
 			commandsByPosition[pos.Position] = pos.Name
 		}
 	}
-	for _, cmd := range p.subcommandInContext.Subcommands {
+	for _, cmd := range p.subcommandContext.Subcommands {
 		if cmd.Hidden {
 			continue
 		}
@@ -180,7 +180,7 @@ func (h *Help) ExtractValues(p *Parser, message string) {
 	var usageString string
 	if highestPosition > 0 {
 		// find each positional value and make our final string
-		usageString = p.subcommandInContext.Name
+		usageString = p.subcommandContext.Name
 		for i := 1; i <= highestPosition; i++ {
 			if len(commandsByPosition[i]) > 0 {
 				usageString = usageString + " [" + commandsByPosition[i] + "]"

--- a/helpValues.go
+++ b/helpValues.go
@@ -90,8 +90,8 @@ func (h *Help) ExtractValues(p *Parser, message string) {
 	// if the built-in version flag is enabled, then add it as a help flag
 	if p.ShowVersionWithVFlag {
 		defaultVersionFlag := HelpFlag{
-			ShortName:    "v",
-			LongName:     "version",
+			ShortName:    versionFlagShortName,
+			LongName:     versionFlagLongName,
 			Description:  "Displays the program version string.",
 			DefaultValue: "",
 		}
@@ -101,8 +101,8 @@ func (h *Help) ExtractValues(p *Parser, message string) {
 	// if the built-in help flag exists, then add it as a help flag
 	if p.ShowHelpWithHFlag {
 		defaultHelpFlag := HelpFlag{
-			ShortName:    "h",
-			LongName:     "help",
+			ShortName:    helpFlagShortName,
+			LongName:     helpFlagLongName,
 			Description:  "Displays help with available flag, subcommand, and positional value parameters.",
 			DefaultValue: "",
 		}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,12 @@ import (
 	"time"
 )
 
+// strings used for builtin help and version flags both short and long
+const versionFlagLongName = "version"
+const versionFlagShortName = "v"
+const helpFlagLongName = "help"
+const helpFlagShortName = "h"
+
 // defaultVersion is applied to parsers when they are created
 const defaultVersion = "0.0.0"
 

--- a/parser.go
+++ b/parser.go
@@ -20,7 +20,7 @@ type Parser struct {
 	HelpTemplate               *template.Template // template for Help output
 	trailingArgumentsExtracted bool               // indicates that tariling args have been parsed and should not be appended again
 	parsed                     bool               // indicates this parser has parsed
-	subcommandInContext        *Subcommand        // points to the most specific subcommand being used
+	subcommandContext          *Subcommand        // points to the most specific subcommand being used
 }
 
 // NewParser creates a new ArgumentParser ready to parse inputs
@@ -33,7 +33,7 @@ func NewParser(name string) *Parser {
 	p.ShowHelpWithHFlag = true
 	p.ShowVersionWithVFlag = true
 	p.SetHelpTemplate(DefaultHelpTemplate)
-	p.subcommandInContext = &Subcommand{}
+	p.subcommandContext = &Subcommand{}
 	return p
 }
 
@@ -81,7 +81,7 @@ func (p *Parser) Parse() error {
 
 // ShowHelp shows Help without an error message
 func (p *Parser) ShowHelp() {
-	debugPrint("showing help for", p.subcommandInContext.Name)
+	debugPrint("showing help for", p.subcommandContext.Name)
 	p.ShowHelpWithMessage("")
 }
 

--- a/parser.go
+++ b/parser.go
@@ -60,7 +60,7 @@ func (p *Parser) ShowVersionAndExit() {
 // Help.
 func (p *Parser) SetHelpTemplate(tmpl string) error {
 	var err error
-	p.HelpTemplate = template.New("Help")
+	p.HelpTemplate = template.New(helpFlagLongName)
 	p.HelpTemplate, err = p.HelpTemplate.Parse(tmpl)
 	if err != nil {
 		return err

--- a/subCommand.go
+++ b/subCommand.go
@@ -88,7 +88,7 @@ func (sc *Subcommand) parseAllFlagsFromArgs(p *Parser, args []string) ([]string,
 		// if the flag being passed is version or v and the option to display
 		// version with version flags, then display version
 		if p.ShowVersionWithVFlag {
-			if flagName == "v" || flagName == "version" {
+			if flagName == versionFlagShortName || flagName == versionFlagLongName {
 				p.ShowVersionAndExit()
 			}
 		}
@@ -96,7 +96,7 @@ func (sc *Subcommand) parseAllFlagsFromArgs(p *Parser, args []string) ([]string,
 		// if the show Help on h flag option is set, then show Help when h or Help
 		// is passed as an option
 		if p.ShowHelpWithHFlag {
-			if flagName == "h" || flagName == "help" {
+			if flagName == helpFlagShortName || flagName == helpFlagLongName {
 				// Ensure this is the last subcommand passed so we give the correct
 				// help output
 				helpRequested = true
@@ -193,6 +193,15 @@ func (sc *Subcommand) parse(p *Parser, args []string, depth int) error {
 	// as subcommands are used, they become the context of the parser.  This helps
 	// us understand how to display help based on which subcommand is being used
 	p.subcommandContext = sc
+
+	// ensure that help and version flags are not used if the parser has the
+	// built-in help and version flags enabled
+	if p.ShowHelpWithHFlag {
+		sc.ensureNoConflictWithBuiltinHelp()
+	}
+	if p.ShowVersionWithVFlag {
+		sc.ensureNoConflictWithBuiltinVersion()
+	}
 
 	// Parse the normal flags out of the argument list and retain the positionals.
 	// Apply the flags to the parent parser and the current subcommand context.
@@ -632,4 +641,66 @@ func (sc *Subcommand) SetValueForKey(key string, value string) (bool, error) {
 
 	// debugPrint(sc.Name, "was unable to find a key named", key, "to set to value", value)
 	return false, nil
+}
+
+// ensureNoConflictWithBuiltinHelp ensures that the flags on this subcommand do
+// not conflict with the builtin help flags (-h or --help). Exits the program
+// if a conflict is found.
+func (sc *Subcommand) ensureNoConflictWithBuiltinHelp() {
+	for _, f := range sc.Flags {
+		if f.LongName == helpFlagLongName {
+			sc.exitBecauseOfHelpFlagConflict(f.LongName)
+		}
+		if f.LongName == helpFlagShortName {
+			sc.exitBecauseOfHelpFlagConflict(f.LongName)
+		}
+		if f.ShortName == helpFlagLongName {
+			sc.exitBecauseOfHelpFlagConflict(f.ShortName)
+		}
+		if f.ShortName == helpFlagShortName {
+			sc.exitBecauseOfHelpFlagConflict(f.ShortName)
+		}
+	}
+}
+
+// ensureNoConflictWithBuiltinVersion ensures that the flags on this subcommand do
+// not conflict with the builtin version flags (-v or --version). Exits the program
+// if a conflict is found.
+func (sc *Subcommand) ensureNoConflictWithBuiltinVersion() {
+	for _, f := range sc.Flags {
+		if f.LongName == versionFlagLongName {
+			sc.exitBecauseOfVersionFlagConflict(f.LongName)
+		}
+		if f.LongName == versionFlagShortName {
+			sc.exitBecauseOfVersionFlagConflict(f.LongName)
+		}
+		if f.ShortName == versionFlagLongName {
+			sc.exitBecauseOfVersionFlagConflict(f.ShortName)
+		}
+		if f.ShortName == versionFlagShortName {
+			sc.exitBecauseOfVersionFlagConflict(f.ShortName)
+		}
+	}
+}
+
+// exitBecauseOfVersionFlagConflict exits the program with a message about how to prevent
+// flags being efined from conflicting with the builtin flags.
+func (sc *Subcommand) exitBecauseOfVersionFlagConflict(flagName string) {
+	fmt.Println(`Command with name '` + flagName + `' conflicts with the internal --version or -v flag in flaggy.
+
+  You must either change the flag's name, or disable flaggy's internal version
+	flag with 'flaggy.DefaultParser.ShowVersionWithVFlag = false'.  If you are using
+	a custom parser, you must instead set '.ShowVersionWithVFlag = false' on it.`)
+	os.Exit(1)
+}
+
+// exitBecauseOfHelpFlagConflict exits the program with a message about how to prevent
+// flags being efined from conflicting with the builtin flags.
+func (sc *Subcommand) exitBecauseOfHelpFlagConflict(flagName string) {
+	fmt.Println(`Command with name '` + flagName + `' conflicts with the internal --help or -h flag in flaggy.
+
+  You must either change the flag's name, or disable flaggy's internal help
+	flag with 'flaggy.DefaultParser.ShowHelpWithHFlag = false'.  If you are using
+	a custom parser, you must instead set '.ShowHelpWithHFlag = false' on it.`)
+	os.Exit(1)
 }

--- a/subCommand.go
+++ b/subCommand.go
@@ -192,7 +192,7 @@ func (sc *Subcommand) parse(p *Parser, args []string, depth int) error {
 
 	// as subcommands are used, they become the context of the parser.  This helps
 	// us understand how to display help based on which subcommand is being used
-	p.subcommandInContext = sc
+	p.subcommandContext = sc
 
 	// Parse the normal flags out of the argument list and retain the positionals.
 	// Apply the flags to the parent parser and the current subcommand context.
@@ -355,7 +355,9 @@ func (sc *Subcommand) AttachSubcommand(newSC *Subcommand, relativePosition int) 
 	return nil
 }
 
-// addFlag is a generic to add flags of any type
+// addFlag is a generic to add flags of any type.  Checks the supplied parent
+// parser to ensure that the user isnt setting version or help flags that
+// conflict with the built-in help and version flag behavior.
 func (sc *Subcommand) add(assignmentVar interface{}, shortName string, longName string, description string) error {
 
 	// if the flag is already used, throw an error


### PR DESCRIPTION
- Fixes #21   
- Displays a message when the program attempts to overwrite builtin `-h`,`--help`,`-v`, or `--version` flags.