### PR TITLE
Process multiple short options with single dash

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -16,6 +16,7 @@ type Parser struct {
 	ShowHelpWithHFlag          bool               // display help when -h or --help passed
 	ShowVersionWithVersionFlag bool               // display the version when --version passed
 	ShowHelpOnUnexpected       bool               // display help when an unexpected flag is passed
+	ProcessMultipleShorts      bool               // process multiple short options like -lvp
 	TrailingArguments          []string           // everything after a -- is placed here
 	HelpTemplate               *template.Template // template for Help output
 	trailingArgumentsExtracted bool               // indicates that trailing args have been parsed and should not be appended again
@@ -31,6 +32,7 @@ func NewParser(name string) *Parser {
 	p.Version = defaultVersion
 	p.ShowHelpOnUnexpected = true
 	p.ShowHelpWithHFlag = true
+        p.ProcessMultipleShorts = false
 	p.ShowVersionWithVersionFlag = true
 	p.SetHelpTemplate(DefaultHelpTemplate)
 	p.subcommandContext = &Subcommand{}


### PR DESCRIPTION
If following option is enabled:
flaggy.DefaultParser.ProcessMultipleShorts = true

following multiple options : -e -x -a -m -p -l
can be written as: -exampl

Since, it breaks previous behaviour, it is added as an
option to the parser.