### PR TITLE
Fix variable shadowing issue in setValueForParsers()

### DIFF
--- a/argumentParser.go
+++ b/argumentParser.go
@@ -8,19 +8,17 @@ package flaggy
 // as we find a parser that accepts it.
 func setValueForParsers(key string, value string, parsers ...ArgumentParser) (bool, error) {
 
-	var valueWasSet bool
-
 	for _, p := range parsers {
 		valueWasSet, err := p.SetValueForKey(key, value)
 		if err != nil {
 			return valueWasSet, err
 		}
 		if valueWasSet {
-			break
+			return true, nil
 		}
 	}
 
-	return valueWasSet, nil
+	return false, nil
 }
 
 // ArgumentParser represents a parser or subcommand


### PR DESCRIPTION
This PR fixes a variable shadowing issue that causes `valueWasSet` not being returned properly in `setValueForParsers()`.