### PR TITLE
Fix bug with bool flags on subcommands

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -407,10 +407,21 @@ func parseFlagToName(arg string) string {
 	return arg
 }
 
+// collectAllNestedFlags recurses through the command tree to get all
+//     flags specified on a subcommand and its descending subcommands
+func collectAllNestedFlags(sc *Subcommand) []*Flag {
+	fullList := sc.Flags
+	for _, sc := range sc.Subcommands {
+		fullList = append(fullList, sc.Flags...)
+		fullList = append(fullList, collectAllNestedFlags(sc)...)
+	}
+	return fullList
+}
+
 // flagIsBool determines if the flag is a bool within the specified parser
 // and subcommand's context
 func flagIsBool(sc *Subcommand, p *Parser, key string) bool {
-	for _, f := range append(sc.Flags, p.Flags...) {
+	for _, f := range append(collectAllNestedFlags(sc), p.Flags...) {
 		if f.HasName(key) {
 			_, isBool := f.AssignmentVar.(*bool)
 			_, isBoolSlice := f.AssignmentVar.(*[]bool)

--- a/subcommand_test.go
+++ b/subcommand_test.go
@@ -768,3 +768,39 @@ func TestSCInputParsing(t *testing.T) {
 		}
 	}
 }
+
+// TestSCBoolFlag tests bool flags on subcommands
+func TestSCBoolFlag(t *testing.T) {
+	p := flaggy.NewParser("TestSubcommandBoolParse")
+	newSC := flaggy.NewSubcommand("testSubcommand")
+
+	var boolFlag bool
+	newSC.Bool(&boolFlag, "f", "flag", "test bool flag on subcommand")
+
+	p.AttachSubcommand(newSC, 1)
+
+	os.Args = []string{"binaryName", "testSubcommand", "--flag"}
+	err := p.Parse()
+	if err != nil {
+		t.Fatal("Error parsing args: " + err.Error())
+	}
+}
+
+// TestNestedSCBoolFlag tests bool flags on nested subcommands
+func TestNestedSCBoolFlag(t *testing.T) {
+	p := flaggy.NewParser("TestSubcommandBoolParse")
+	newSC := flaggy.NewSubcommand("mainSubcommand")
+	subSC := flaggy.NewSubcommand("subSubCommand")
+
+	var boolFlag bool
+	subSC.Bool(&boolFlag, "f", "flag", "test bool flag on subcommand")
+
+	newSC.AttachSubcommand(subSC, 1)
+	p.AttachSubcommand(newSC, 1)
+
+	os.Args = []string{"binaryName", "mainSubcommand", "subSubCommand", "--flag"}
+	err := p.Parse()
+	if err != nil {
+		t.Fatal("Error parsing args: " + err.Error())
+	}
+}


### PR DESCRIPTION
Fixes error for valid bool flags "expected a following arg for flag <flag>, but it did not exist"

The fix is to check flags on all nested subcommands when determining if a flag is a bool

This fixes issue #57 