### PR TITLE
unknown arg identification skips test. flags injected by go test

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"text/template"
 )
@@ -80,6 +81,11 @@ func findArgsNotInParsedValues(args []string, parsedValues []parsedValue) []stri
 	var argsNotUsed []string
 	var skipNext bool
 	for _, a := range args {
+
+		// skip args that start with 'test.' because they are injected with go test
+		if strings.HasPrefix(a, "test.") {
+			continue
+		}
 
 		// if the final argument (--) is seen, then we stop checking because all
 		// further values are trailing arguments.


### PR DESCRIPTION
When using show help on unexpected, test runs will break due to the injected test flags.

This PR fixes this situation:

```
$ go test
Unknown arguments supplied:  test.v=true test.timeout=10m0s
exit status 2
```