### PR TITLE
Parsing errors was silenced!

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -53,7 +53,7 @@ func (p *Parser) ParseArgs(args []string) error {
 	debugPrint("Kicking off parsing with args:", args)
 	err := p.parse(p, args, 0)
 	if err != nil {
-		return err
+		p.ShowHelpAndExit("Parse error: " + err.Error())
 	}
 
 	// if we are set to crash on unexpected args, look for those here TODO

--- a/subCommand.go
+++ b/subCommand.go
@@ -689,7 +689,10 @@ func (sc *Subcommand) SetValueForKey(key string, value string) (bool, error) {
 		// debugPrint("Evaluating string flag", f.ShortName, "==", key, "||", f.LongName, "==", key)
 		if f.ShortName == key || f.LongName == key {
 			// debugPrint("Setting string value for", key, "to", value)
-			f.identifyAndAssignValue(value)
+			err := f.identifyAndAssignValue(value)
+			if err != nil {
+				return false, err
+			}
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Hello!

Currently if passed flag has bad value the parsing error is silenced.
In this case flag variable dont changed and saves original default value.

```go
func main() {
	var intFlag = 123456
	flaggy.Int(&intFlag, "f", "flag", "A test string flag")
	flaggy.Parse()

	// go run main.go --flag abc
	print(intFlag) // 123456
}
```

I think this behavior is strange and triggers wrong software behavior.

What do you think about this?