### PR TITLE
Linter fixes

### DIFF
--- a/helpValues.go
+++ b/helpValues.go
@@ -218,7 +218,7 @@ func (h *Help) parseFlagsToHelpFlags(flags []*Flag, maxLength int) {
 		_, isBool := f.AssignmentVar.(*bool)
 		if isBool {
 			b := f.AssignmentVar.(*bool)
-			if *b == false {
+			if !*b {
 				defaultValue = ""
 			}
 		}

--- a/helpValues.go
+++ b/helpValues.go
@@ -52,7 +52,6 @@ type HelpFlag struct {
 // parser. The parser is required in order to detect default flag settings
 // for help and version output.
 func (h *Help) ExtractValues(p *Parser, message string) {
-
 	// accept message string for output
 	h.Message = message
 
@@ -187,13 +186,11 @@ func (h *Help) ExtractValues(p *Parser, message string) {
 	}
 
 	h.UsageString = usageString
-
 }
 
 // parseFlagsToHelpFlags parses the specified slice of flags into
 // help flags on the the calling help command
 func (h *Help) parseFlagsToHelpFlags(flags []*Flag, maxLength int) {
-
 	for _, f := range flags {
 		if f.Hidden {
 			continue

--- a/parser_test.go
+++ b/parser_test.go
@@ -45,7 +45,7 @@ func TestFindArgsNotInParsedValues(t *testing.T) {
 
 	// ensure regular values are not skipped
 	parsedValues = []parsedValue{
-		parsedValue{
+		{
 			Key:   "flaggy",
 			Value: "testing",
 		},

--- a/subcommand_test.go
+++ b/subcommand_test.go
@@ -155,7 +155,9 @@ func TestTypoSubcommand(t *testing.T) {
 	newSCB := flaggy.NewSubcommand("TestTypoSubcommandB")
 	p.AttachSubcommand(newSCA, 1)
 	p.AttachSubcommand(newSCB, 1)
-	p.ParseArgs(args)
+	if err := p.ParseArgs(args); err != nil {
+		t.Fatalf("got: %s; want: no error", err)
+	}
 }
 
 // TestIgnoreUnexpected tests what happens when an invalid subcommand is passed but should be ignored
@@ -165,7 +167,9 @@ func TestIgnoreUnexpected(t *testing.T) {
 	args := []string{"unexpectedArg"}
 	newSCA := flaggy.NewSubcommand("TestTypoSubcommandA")
 	p.AttachSubcommand(newSCA, 1)
-	p.ParseArgs(args)
+	if err := p.ParseArgs(args); err != nil {
+		t.Fatalf("got: %s; want: no error", err)
+	}
 }
 
 // TestSubcommandHelp tests displaying of help on unspecified commands
@@ -179,7 +183,9 @@ func TestSubcommandHelp(t *testing.T) {
 	p := flaggy.NewParser("TestSubcommandHelp")
 	p.ShowHelpOnUnexpected = true
 	args := []string{"unexpectedArg"}
-	p.ParseArgs(args)
+	if err := p.ParseArgs(args); err != nil {
+		t.Fatalf("got: %s; want: no error", err)
+	}
 }
 
 func TestHelpWithHFlagA(t *testing.T) {
@@ -192,7 +198,9 @@ func TestHelpWithHFlagA(t *testing.T) {
 	p := flaggy.NewParser("TestHelpWithHFlag")
 	p.ShowHelpWithHFlag = true
 	args := []string{"-h"}
-	p.ParseArgs(args)
+	if err := p.ParseArgs(args); err != nil {
+		t.Fatalf("got: %s; want: no error", err)
+	}
 }
 
 func TestHelpWithHFlagB(t *testing.T) {
@@ -205,7 +213,9 @@ func TestHelpWithHFlagB(t *testing.T) {
 	p := flaggy.NewParser("TestHelpWithHFlag")
 	p.ShowHelpWithHFlag = true
 	args := []string{"--help"}
-	p.ParseArgs(args)
+	if err := p.ParseArgs(args); err != nil {
+		t.Fatalf("got: %s; want: no error", err)
+	}
 }
 
 func TestVersionWithVFlagB(t *testing.T) {
@@ -219,7 +229,9 @@ func TestVersionWithVFlagB(t *testing.T) {
 	p.ShowVersionWithVersionFlag = true
 	p.Version = "TestVersionWithVFlagB 0.0.0a"
 	args := []string{"--version"}
-	p.ParseArgs(args)
+	if err := p.ParseArgs(args); err != nil {
+		t.Fatalf("got: %s; want: no error", err)
+	}
 }
 
 // TestSubcommandParse tests paring of a single subcommand
@@ -241,7 +253,9 @@ func TestSubcommandParse(t *testing.T) {
 
 	// override os args and parse them
 	os.Args = []string{"binaryName", "testSubcommand", "testPositional"}
-	p.Parse()
+	if err := p.Parse(); err != nil {
+		t.Fatalf("got: %s; want: no error", err)
+	}
 
 	// ensure subcommand and positional used
 	if !newSC.Used {
@@ -262,7 +276,9 @@ func TestBadSubcommand(t *testing.T) {
 
 	//  test what happens if you add a bad subcommand
 	os.Args = []string{"test"}
-	p.Parse()
+	if err := p.Parse(); err != nil {
+		t.Fatalf("got: %s; want: no error", err)
+	}
 }
 
 func TestBadPositional(t *testing.T) {

--- a/subcommand_test.go
+++ b/subcommand_test.go
@@ -21,7 +21,6 @@ func TestSCNameExists(t *testing.T) {
 	scB := flaggy.NewSubcommand("test")
 	flaggy.AttachSubcommand(scA, 1)
 	flaggy.AttachSubcommand(scB, 1)
-
 }
 
 func TestFlagExists(t *testing.T) {
@@ -37,7 +36,6 @@ func TestFlagExists(t *testing.T) {
 	if e == false {
 		t.Fatal("Flag does not exist on a subcommand that should")
 	}
-
 }
 
 // TestExitOnUnknownFlag tests that when an unknown flag is supplied and the
@@ -255,7 +253,6 @@ func TestSubcommandParse(t *testing.T) {
 }
 
 func TestBadSubcommand(t *testing.T) {
-
 	// create the argument parser
 	p := flaggy.NewParser("TestBadSubcommand")
 
@@ -269,7 +266,6 @@ func TestBadSubcommand(t *testing.T) {
 }
 
 func TestBadPositional(t *testing.T) {
-
 	// create the argument parser
 	p := flaggy.NewParser("TestBadPositional")
 
@@ -310,7 +306,6 @@ func debugOff() {
 // BenchmarkSubcommandParse benchmarks the creation and parsing of
 // a basic subcommand
 func BenchmarkSubcommandParse(b *testing.B) {
-
 	// catch errors that may occur
 	defer func(b *testing.B) {
 		err := recover()
@@ -342,7 +337,6 @@ func BenchmarkSubcommandParse(b *testing.B) {
 			b.Fatal("Error parsing args: " + err.Error())
 		}
 	}
-
 }
 
 // TestSCInputParsing tests all flag types on subcommands


### PR DESCRIPTION
This series of fixes silent various linter complaints.
Each commit fixes a specific complaint, so that:
- it is easier to understand what is being fixed
- in case you disagree, the specific commit can easily be dropped.