### PR TITLE
fix: fail on parse errors instead of silently ignoring them

### DIFF
--- a/subCommand.go
+++ b/subCommand.go
@@ -689,7 +689,9 @@ func (sc *Subcommand) SetValueForKey(key string, value string) (bool, error) {
 		// debugPrint("Evaluating string flag", f.ShortName, "==", key, "||", f.LongName, "==", key)
 		if f.ShortName == key || f.LongName == key {
 			// debugPrint("Setting string value for", key, "to", value)
-			f.identifyAndAssignValue(value)
+			if err := f.identifyAndAssignValue(value); err != nil {
+				return false, err
+			}
 			return true, nil
 		}
 	}

--- a/subcommand_test.go
+++ b/subcommand_test.go
@@ -804,3 +804,18 @@ func TestNestedSCBoolFlag(t *testing.T) {
 		t.Fatal("Error parsing args: " + err.Error())
 	}
 }
+
+func TestParseErrorsAreReportedRegression(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("Expected crash on invalid syntax")
+		}
+	}()
+
+	flaggy.ResetParser()
+	intFlag := 42
+	flaggy.Int(&intFlag, "i", "int", "dummy")
+	os.Args = []string{"prog", "--int", "abc"}
+	flaggy.Parse()
+}


### PR DESCRIPTION
This is the same as PR #64, but adds a regression test and doesn't modify
ParseArgs().