### PR TITLE
blackbox test: actually assert something

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/integrii/flaggy
 
 go 1.12
+
+require github.com/google/go-cmp v0.5.6 // for tests only

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/helpValues_blackbox_test.go
+++ b/helpValues_blackbox_test.go
@@ -1,29 +1,63 @@
 package flaggy_test
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/integrii/flaggy"
 )
 
 func TestMinimalHelpOutput(t *testing.T) {
 	p := flaggy.NewParser("TestMinimalHelpOutput")
+
+	rd, wr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: error: %s", err)
+	}
+	savedStderr := os.Stderr
+	os.Stderr = wr
+
+	defer func() {
+		os.Stderr = savedStderr
+	}()
+
 	p.ShowHelp()
+
+	buf := make([]byte, 1024)
+	n, err := rd.Read(buf)
+	if err != nil {
+		t.Fatalf("read: error: %s", err)
+	}
+	got := strings.Split(string(buf[:n]), "\n")
+	want := []string{
+		"",
+		"",
+		"  Flags: ",
+		"       --version   Displays the program version string.",
+		"    -h --help      Displays help with available flag, subcommand, and positional value parameters.",
+		"",
+		"",
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("help mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestHelpWithMissingSCName(t *testing.T) {
 	defer func() {
 		r := recover()
-		if r == nil {
-			t.Fatal("Expected panic with subcommand avilability at position, but did not get one")
+		gotMsg := r.(string)
+		wantMsg := "Panic instead of exit with code: 2"
+		if gotMsg != wantMsg {
+			t.Fatalf("error: got: %s; want: %s", gotMsg, wantMsg)
 		}
 	}()
 	flaggy.ResetParser()
-	sc := flaggy.NewSubcommand("")
-	sc.ShortName = "sn"
-	flaggy.AttachSubcommand(sc, 1)
-	flaggy.ParseArgs([]string{"x"})
+	flaggy.NewSubcommand("")
 }
 
 // TestHelpOutput tests the dislay of help with -h
@@ -61,6 +95,45 @@ func TestHelpOutput(t *testing.T) {
 	p.Duration(&durationFlag, "d", "durationFlag", "This is a test duration flag that does some untimely stuff.")
 	p.AdditionalHelpPrepend = "This is a prepend for help"
 	p.AdditionalHelpAppend = "This is an append for help"
-	p.ParseArgs([]string{"subcommandA", "subcommandB", "hiddenPositional1"})
+
+	rd, wr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: error: %s", err)
+	}
+	savedStderr := os.Stderr
+	os.Stderr = wr
+
+	defer func() {
+		os.Stderr = savedStderr
+	}()
+
+	if err := p.ParseArgs([]string{"subcommandA", "subcommandB", "hiddenPositional1"}); err != nil {
+		t.Fatalf("got: %s; want: no error", err)
+	}
 	p.ShowHelpWithMessage("This is a help message on exit")
+
+	buf := make([]byte, 1024)
+	n, err := rd.Read(buf)
+	if err != nil {
+		t.Fatalf("read: error: %s", err)
+	}
+	got := strings.Split(string(buf[:n]), "\n")
+	want := []string{
+		"subcommandB - Subcommand B is a command that does other stuff",
+		"",
+		"  Flags: ",
+		"       --version        Displays the program version string.",
+		"    -h --help           Displays help with available flag, subcommand, and positional value parameters.",
+		"    -s --stringFlag     This is a test string flag that does some stringy string stuff. (default: defaultStringHere)",
+		"    -i --intFlg         This is a test int flag that does some interesting int stuff. (default: 0)",
+		"    -b --boolFlag       This is a test bool flag that does some booly bool stuff.",
+		"    -d --durationFlag   This is a test duration flag that does some untimely stuff. (default: 0s)",
+		"",
+		"This is a help message on exit",
+		"",
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("help mismatch (-want +got):\n%s", diff)
+	}
 }


### PR DESCRIPTION
The helpValues_blackbox_test was not asserting anything. We now intercept stderr and validate that the help output is what is expected.

Note that the added dependency in go.mod github.com/google/go-cmp is used _only_ by the tests.