### PR TITLE
Expose terminal subcommand

### DIFF
--- a/flaggy_test.go
+++ b/flaggy_test.go
@@ -108,6 +108,9 @@ func TestComplexNesting(t *testing.T) {
 		t.Log("testE", testE)
 		t.FailNow()
 	}
+	if subcommandName := flaggy.DefaultParser.TerminalSubcommand().Name; subcommandName != "scD" {
+		t.Fatal("Used subcommand was incorrect:", subcommandName)
+	}
 
 }
 
@@ -176,6 +179,9 @@ func TestParsePositionalsA(t *testing.T) {
 	}
 	if parser.TrailingArguments[1] != "trailingB" {
 		t.Fatal("Trailing argumentB was incorrect:", parser.TrailingArguments[1])
+	}
+	if subcommandName := parser.TerminalSubcommand().Name; subcommandName != "subcommand" {
+		t.Fatal("Used subcommand was incorrect:", subcommandName)
 	}
 
 }

--- a/flaggy_test.go
+++ b/flaggy_test.go
@@ -108,7 +108,7 @@ func TestComplexNesting(t *testing.T) {
 		t.Log("testE", testE)
 		t.FailNow()
 	}
-	if subcommandName := flaggy.DefaultParser.TerminalSubcommand().Name; subcommandName != "scD" {
+	if subcommandName := flaggy.DefaultParser.TrailingSubcommand().Name; subcommandName != "scD" {
 		t.Fatal("Used subcommand was incorrect:", subcommandName)
 	}
 
@@ -180,7 +180,7 @@ func TestParsePositionalsA(t *testing.T) {
 	if parser.TrailingArguments[1] != "trailingB" {
 		t.Fatal("Trailing argumentB was incorrect:", parser.TrailingArguments[1])
 	}
-	if subcommandName := parser.TerminalSubcommand().Name; subcommandName != "subcommand" {
+	if subcommandName := parser.TrailingSubcommand().Name; subcommandName != "subcommand" {
 		t.Fatal("Used subcommand was incorrect:", subcommandName)
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -26,7 +26,8 @@ type Parser struct {
 	subcommandContext          *Subcommand        // points to the most specific subcommand being used
 }
 
-func (p *Parser) TerminalSubcommand() *Subcommand {
+TrailingSubcommand returns the last and most specific subcommand invoked.
+func (p *Parser) TrailingSubcommand() *Subcommand {
 	return p.subcommandContext
 }
 

--- a/parser.go
+++ b/parser.go
@@ -26,6 +26,10 @@ type Parser struct {
 	subcommandContext          *Subcommand        // points to the most specific subcommand being used
 }
 
+func (p *Parser) TerminalSubcommand() *Subcommand {
+	return p.subcommandContext
+}
+
 // NewParser creates a new ArgumentParser ready to parse inputs
 func NewParser(name string) *Parser {
 	// this can not be done inline because of struct embedding


### PR DESCRIPTION
For use cases where only the final subcommand in the sequence needs to be run
(e.g. `git remote add` just runs the `add` subcommand of `remote`), it would be
useful to identify that subcommand directly.  Since that pointer is already
helpfully stored in the parser, simply exposing it via a method worked nicely.