### PR TITLE
Add useful info to AddPositionalValue panic.

### DIFF
--- a/subCommand.go
+++ b/subCommand.go
@@ -656,14 +656,14 @@ func (sc *Subcommand) AddPositionalValue(assignmentVar *string, name string, rel
 	// ensure no other positionals are at this depth
 	for _, other := range sc.PositionalFlags {
 		if relativePosition == other.Position {
-			log.Panicln("Unable to add positional value because one already exists at position: " + strconv.Itoa(relativePosition))
+			log.Panicln("Unable to add positional value " + name + " because " + other.Name + " already exists at position: " + strconv.Itoa(relativePosition))
 		}
 	}
 
 	// ensure no subcommands at this depth
 	for _, other := range sc.Subcommands {
 		if relativePosition == other.Position {
-			log.Panicln("Unable to add positional value a subcommand already exists at position: " + strconv.Itoa(relativePosition))
+			log.Panicln("Unable to add positional value " + name + "because a subcommand, " + other.Name + ", already exists at position: " + strconv.Itoa(relativePosition))
 		}
 	}
 


### PR DESCRIPTION
Working on a somewhat complicated CLI and kept getting this vague panic about a positional value.

This PR inserts the names of the positional values into the panic message to assist the developer.