### PR TITLE
correct match parsed flag when it has same shortname with subcommand

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
 	"text/template"
 )
 
@@ -94,7 +93,8 @@ func findArgsNotInParsedValues(args []string, parsedValues []parsedValue) []stri
 
 		// if the final argument (--) is seen, then we stop checking because all
 		// further values are trailing arguments.
-		if determineArgType(a) == argIsFinal {
+		argType := determineArgType(a)
+		if argType == argIsFinal {
 			return argsNotUsed
 		}
 
@@ -122,10 +122,10 @@ func findArgsNotInParsedValues(args []string, parsedValues []parsedValue) []stri
 
 		// search all args for a corresponding parsed value
 		for _, pv := range parsedValues {
-			// this argumenet was a key
+			// this argument was a key
 			// debugPrint(pv.Key, "==", arg)
 			debugPrint(pv.Key + "==" + arg + " || (" + strconv.FormatBool(pv.IsPositional) + " && " + pv.Value + " == " + arg + ")")
-			if pv.Key == arg || (pv.IsPositional && pv.Value == arg) {
+			if pv.Key == arg || (argType == argIsPositional && pv.IsPositional && pv.Value == arg) {
 				debugPrint("Found matching parsed arg for " + pv.Key)
 				foundArgUsed = true // the arg was used in this parsedValues set
 				// if the value is not a positional value and the parsed value had a

--- a/parser.go
+++ b/parser.go
@@ -145,7 +145,7 @@ func findArgsNotInParsedValues(args []string, parsedValues []parsedValue) []stri
 		// if the arg was not used in any parsed values, then we add it to the slice
 		// of arguments not used
 		if !foundArgUsed {
-			argsNotUsed = append(argsNotUsed, arg)
+			argsNotUsed = append(argsNotUsed, a)
 		}
 	}
 

--- a/subCommand.go
+++ b/subCommand.go
@@ -162,7 +162,7 @@ func (sc *Subcommand) parseAllFlagsFromArgs(p *Parser, args []string) ([]string,
 
 			// if the next arg was not found, then show a Help message
 			if !nextArgExists {
-				p.ShowHelpWithMessage("Expected a following arg for flag " + a + ", but it did not exist.")
+				p.ShowHelpWithMessage("Expected a following arg for flag " + args[i] + ", but it did not exist.")
 				exitOrPanic(2)
 			}
 			valueSet, err := setValueForParsers(a, nextArg, p, sc)


### PR DESCRIPTION
fix #84 