### PR TITLE
Add built-in bash and zsh completion generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Check out the [go doc](http://pkg.go.dev/github.com/integrii/flaggy), [examples 
 - Optional but default version output with `--version`
 - Optional but default help output with `-h` or `--help`
 - Optional but default help output when any invalid or unknown parameter is passed
+- Optional bash and zsh shell completion generation
 - It's _fast_. All flag and subcommand parsing takes less than `1ms` in most programs.
 
 # Example Help Output
@@ -171,6 +172,26 @@ Other more specific types can also be used as flag types.  They will be automati
 - []net.IPMask
 - time.Duration
 - []time.Duration
+
+# Shell Completion
+
+Flaggy generates Bash and zsh completion scripts from your parser's flags,
+positional arguments, and subcommands. Enable the built-in `completion`
+subcommand after parser initialization:
+
+```go
+flaggy.EnableCompletion() // or parser.EnableCompletion() if you use a custom parser
+```
+
+Users can then run your application to output a completion script:
+
+```bash
+./app completion bash > /usr/local/etc/bash_completion.d/app
+source /usr/local/etc/bash_completion.d/app
+```
+
+Replace `bash` with `zsh` to generate a zsh shell script. No external
+dependencies are required.
 
 # An Example Program
 

--- a/completion.go
+++ b/completion.go
@@ -1,0 +1,118 @@
+package flaggy
+
+import (
+	"strings"
+)
+
+// EnableCompletion attaches a built-in 'completion' subcommand that outputs
+// shell completion scripts for bash or zsh.
+func (p *Parser) EnableCompletion() {
+	sc := NewSubcommand("completion")
+	sc.Description = "generate shell completion script"
+	sc.AddPositionalValue(&p.completionShell, "shell", 1, true, "shell type (bash or zsh)")
+	p.AttachSubcommand(sc, 1)
+	p.completionCommand = sc
+}
+
+// EnableCompletion attaches the completion subcommand to the default parser.
+func EnableCompletion() {
+	DefaultParser.EnableCompletion()
+}
+
+// GenerateBashCompletion returns a bash completion script for the parser.
+func GenerateBashCompletion(p *Parser) string {
+	var b strings.Builder
+	funcName := "_" + sanitizeName(p.Name) + "_complete"
+	b.WriteString("# bash completion for " + p.Name + "\n")
+	b.WriteString(funcName + "() {\n")
+	b.WriteString("    local cur prev\n")
+	b.WriteString("    COMPREPLY=()\n")
+	b.WriteString("    cur=\"${COMP_WORDS[COMP_CWORD]}\"\n")
+	b.WriteString("    prev=\"${COMP_WORDS[COMP_CWORD-1]}\"\n")
+	b.WriteString("    case \"$prev\" in\n")
+	bashCaseEntries(&p.Subcommand, &b)
+	rootOpts := collectOptions(&p.Subcommand)
+	b.WriteString("        *)\n            COMPREPLY=( $(compgen -W \"" + rootOpts + "\" -- \"$cur\") )\n            return 0\n            ;;\n    esac\n}\n")
+	b.WriteString("complete -F " + funcName + " " + p.Name + "\n")
+	return b.String()
+}
+
+// GenerateZshCompletion returns a zsh completion script for the parser.
+func GenerateZshCompletion(p *Parser) string {
+	var b strings.Builder
+	funcName := "_" + sanitizeName(p.Name)
+	b.WriteString("#compdef " + p.Name + "\n\n")
+	b.WriteString(funcName + "() {\n")
+	b.WriteString("    local cur prev\n")
+	b.WriteString("    cur=${words[CURRENT]}\n")
+	b.WriteString("    prev=${words[CURRENT-1]}\n")
+	b.WriteString("    case \"$prev\" in\n")
+	zshCaseEntries(&p.Subcommand, &b)
+	rootOpts := collectOptions(&p.Subcommand)
+	b.WriteString("        *)\n            compadd -- " + rootOpts + "\n            ;;\n    esac\n}\n")
+	b.WriteString("compdef " + funcName + " " + p.Name + "\n")
+	return b.String()
+}
+
+// collectOptions builds a space-delimited list of flags, subcommands, and positional values
+// for the provided subcommand.
+func collectOptions(sc *Subcommand) string {
+	var opts []string
+	for _, f := range sc.Flags {
+		if len(f.ShortName) > 0 {
+			opts = append(opts, "-"+f.ShortName)
+		}
+		if len(f.LongName) > 0 {
+			opts = append(opts, "--"+f.LongName)
+		}
+	}
+	for _, p := range sc.PositionalFlags {
+		if p.Name != "" {
+			opts = append(opts, p.Name)
+		}
+	}
+	for _, s := range sc.Subcommands {
+		if s.Hidden {
+			continue
+		}
+		if s.Name != "" {
+			opts = append(opts, s.Name)
+		}
+		if s.ShortName != "" {
+			opts = append(opts, s.ShortName)
+		}
+	}
+	return strings.Join(opts, " ")
+}
+
+func bashCaseEntries(sc *Subcommand, b *strings.Builder) {
+	for _, s := range sc.Subcommands {
+		if s.Hidden {
+			continue
+		}
+		opts := collectOptions(s)
+		b.WriteString("        " + s.Name + ")\n            COMPREPLY=( $(compgen -W \"" + opts + "\" -- \"$cur\") )\n            return 0\n            ;;\n")
+		if s.ShortName != "" {
+			b.WriteString("        " + s.ShortName + ")\n            COMPREPLY=( $(compgen -W \"" + opts + "\" -- \"$cur\") )\n            return 0\n            ;;\n")
+		}
+		bashCaseEntries(s, b)
+	}
+}
+
+func zshCaseEntries(sc *Subcommand, b *strings.Builder) {
+	for _, s := range sc.Subcommands {
+		if s.Hidden {
+			continue
+		}
+		opts := collectOptions(s)
+		b.WriteString("        " + s.Name + ")\n            compadd -- " + opts + "\n            return\n            ;;\n")
+		if s.ShortName != "" {
+			b.WriteString("        " + s.ShortName + ")\n            compadd -- " + opts + "\n            return\n            ;;\n")
+		}
+		zshCaseEntries(s, b)
+	}
+}
+
+func sanitizeName(n string) string {
+	return strings.ReplaceAll(n, "-", "_")
+}

--- a/completion_test.go
+++ b/completion_test.go
@@ -1,0 +1,48 @@
+package flaggy_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/integrii/flaggy"
+)
+
+func TestGenerateBashCompletion(t *testing.T) {
+	p := flaggy.NewParser("testapp")
+	var str string
+	p.String(&str, "", "testflag", "flag for testing")
+	p.AddPositionalValue(&str, "pos", 2, false, "positional")
+	sub := flaggy.NewSubcommand("sub")
+	p.AttachSubcommand(sub, 1)
+
+	out := flaggy.GenerateBashCompletion(p)
+	if !strings.Contains(out, "--testflag") {
+		t.Fatalf("expected flag in bash completion output: %s", out)
+	}
+	if !strings.Contains(out, "sub") {
+		t.Fatalf("expected subcommand in bash completion output: %s", out)
+	}
+	if !strings.Contains(out, "pos") {
+		t.Fatalf("expected positional in bash completion output: %s", out)
+	}
+}
+
+func TestGenerateZshCompletion(t *testing.T) {
+	p := flaggy.NewParser("testapp")
+	var str string
+	p.String(&str, "", "testflag", "flag for testing")
+	p.AddPositionalValue(&str, "pos", 2, false, "positional")
+	sub := flaggy.NewSubcommand("sub")
+	p.AttachSubcommand(sub, 1)
+
+	out := flaggy.GenerateZshCompletion(p)
+	if !strings.Contains(out, "--testflag") {
+		t.Fatalf("expected flag in zsh completion output: %s", out)
+	}
+	if !strings.Contains(out, "sub") {
+		t.Fatalf("expected subcommand in zsh completion output: %s", out)
+	}
+	if !strings.Contains(out, "pos") {
+		t.Fatalf("expected positional in zsh completion output: %s", out)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -24,6 +24,8 @@ type Parser struct {
 	trailingArgumentsExtracted bool               // indicates that trailing args have been parsed and should not be appended again
 	parsed                     bool               // indicates this parser has parsed
 	subcommandContext          *Subcommand        // points to the most specific subcommand being used
+	completionCommand          *Subcommand        // optional completion generation subcommand
+	completionShell            string             // shell type requested for completion
 }
 
 // TrailingSubcommand returns the last and most specific subcommand invoked.
@@ -74,6 +76,18 @@ func (p *Parser) ParseArgs(args []string) error {
 			}
 			p.ShowHelpAndExit("Unknown arguments supplied: " + argsNotParsedFlat)
 		}
+	}
+
+	if p.completionCommand != nil && p.completionCommand.Used {
+		switch p.completionShell {
+		case "bash":
+			fmt.Print(GenerateBashCompletion(p))
+		case "zsh":
+			fmt.Print(GenerateZshCompletion(p))
+		default:
+			fmt.Fprintf(os.Stderr, "Unsupported shell for completion: %s\n", p.completionShell)
+		}
+		exitOrPanic(0)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- support attaching a `completion` subcommand that outputs bash or zsh completion scripts
- generate completion scripts based on parser flags, subcommands, and positional values
- document how to enable and use the built-in completion generators

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c3d2df16188323850d5bc75ffb8ec9