### PR TITLE
Add fish, PowerShell, and Nushell completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Check out the [go doc](http://pkg.go.dev/github.com/integrii/flaggy), [examples 
 - Optional but default version output with `--version`
 - Optional but default help output with `-h` or `--help`
 - Optional but default help output when any invalid or unknown parameter is passed
-- bash and zsh shell completion generation by default
+- bash, zsh, fish, PowerShell, and Nushell shell completion generation by default
 - It's _fast_. All flag and subcommand parsing takes less than `1ms` in most programs.
 
 # Example Help Output
@@ -169,10 +169,24 @@ Flaggy has specific flag types for all basic Go types as well as slice variants,
 
 # Shell Completion
 
-Flaggy generates `bash` and `zsh` completion scripts automatically.
+Flaggy generates `bash`, `zsh`, `fish`, `PowerShell`, and `Nushell` completion scripts automatically.
 
 ```bash
+# Bash
 source <(./app completion bash)
+
+# Zsh
+source <(./app completion zsh)
+
+# Fish
+./app completion fish | source
+
+# PowerShell
+./app completion powershell | Out-String | Invoke-Expression
+
+# Nushell
+./app completion nushell | save --force ~/.cache/app-completions.nu
+source ~/.cache/app-completions.nu
 ```
 
 # An Example Program

--- a/completion.go
+++ b/completion.go
@@ -1,6 +1,7 @@
 package flaggy
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -9,7 +10,7 @@ func EnableCompletion() {
 	DefaultParser.ShowCompletion = true
 }
 
-// EnableCompletion disallows shell autocomplete outputs to be generated.
+// DisableCompletion disallows shell autocomplete outputs to be generated.
 func DisableCompletion() {
 	DefaultParser.ShowCompletion = false
 }
@@ -46,6 +47,46 @@ func GenerateZshCompletion(p *Parser) string {
 	rootOpts := collectOptions(&p.Subcommand)
 	b.WriteString("        *)\n            compadd -- " + rootOpts + "\n            ;;\n    esac\n}\n")
 	b.WriteString("compdef " + funcName + " " + p.Name + "\n")
+	return b.String()
+}
+
+// GenerateFishCompletion returns a fish completion script for the parser.
+func GenerateFishCompletion(p *Parser) string {
+	var b strings.Builder
+	b.WriteString("# fish completion for " + p.Name + "\n")
+	writeFishEntries(&p.Subcommand, &b, p.Name, nil)
+	return b.String()
+}
+
+// GeneratePowerShellCompletion returns a PowerShell completion script for the parser.
+func GeneratePowerShellCompletion(p *Parser) string {
+	var b strings.Builder
+	b.WriteString("# PowerShell completion for " + p.Name + "\n")
+	b.WriteString("Register-ArgumentCompleter -CommandName '" + p.Name + "' -ScriptBlock {\n")
+	b.WriteString("    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)\n")
+	b.WriteString("    $completions = @(\n")
+	writePowerShellEntries(&p.Subcommand, &b)
+	b.WriteString("    )\n")
+	b.WriteString("    $completions | Where-Object { $_.CompletionText -like \"$wordToComplete*\" }\n")
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// GenerateNushellCompletion returns a Nushell completion script for the parser.
+func GenerateNushellCompletion(p *Parser) string {
+	var b strings.Builder
+	command := p.Name
+	funcName := "nu-complete " + command
+	b.WriteString("# nushell completion for " + command + "\n")
+	b.WriteString("def \"" + funcName + "\" [] {\n")
+	b.WriteString("    [\n")
+	writeNushellEntries(&p.Subcommand, &b)
+	b.WriteString("    ]\n")
+	b.WriteString("}\n\n")
+	b.WriteString("extern \"" + command + "\" [\n")
+	writeNushellFlagSignature(&p.Subcommand, &b)
+	b.WriteString("    command?: string@\"" + funcName + "\"\n")
+	b.WriteString("]\n")
 	return b.String()
 }
 
@@ -110,4 +151,240 @@ func zshCaseEntries(sc *Subcommand, b *strings.Builder) {
 
 func sanitizeName(n string) string {
 	return strings.ReplaceAll(n, "-", "_")
+}
+
+// writeFishEntries builds the fish completion statements for the provided subcommand path so
+// the generated script mirrors Flaggy's flag and subcommand hierarchy for interactive use.
+func writeFishEntries(sc *Subcommand, b *strings.Builder, command string, path []string) {
+	condition := fishConditionForFlags(path)
+	for _, f := range sc.Flags {
+		if f.Hidden {
+			continue
+		}
+		line := "complete -c " + command
+		if condition != "" {
+			line += " -n '" + condition + "'"
+		}
+		if f.ShortName != "" {
+			line += " -s " + f.ShortName
+		}
+		if f.LongName != "" {
+			line += " -l " + f.LongName
+		}
+		if f.Description != "" {
+			line += " -d '" + escapeSingleQuotes(f.Description) + "'"
+		}
+		line += "\n"
+		b.WriteString(line)
+	}
+	for _, p := range sc.PositionalFlags {
+		if p.Hidden {
+			continue
+		}
+		if p.Name == "" {
+			continue
+		}
+		line := "complete -c " + command
+		if condition != "" {
+			line += " -n '" + condition + "'"
+		}
+		line += " -a '" + escapeSingleQuotes(p.Name) + "'"
+		if p.Description != "" {
+			line += " -d '" + escapeSingleQuotes(p.Description) + "'"
+		}
+		line += "\n"
+		b.WriteString(line)
+	}
+	subCondition := fishConditionForSubcommands(path)
+	for _, sub := range sc.Subcommands {
+		if sub.Hidden {
+			continue
+		}
+		line := "complete -c " + command
+		if subCondition != "" {
+			line += " -n '" + subCondition + "'"
+		}
+		line += " -a '" + escapeSingleQuotes(sub.Name) + "'"
+		if sub.Description != "" {
+			line += " -d '" + escapeSingleQuotes(sub.Description) + "'"
+		}
+		line += "\n"
+		b.WriteString(line)
+		if sub.ShortName != "" {
+			aliasLine := "complete -c " + command
+			if subCondition != "" {
+				aliasLine += " -n '" + subCondition + "'"
+			}
+			aliasLine += " -a '" + escapeSingleQuotes(sub.ShortName) + "'"
+			if sub.Description != "" {
+				aliasLine += " -d '" + escapeSingleQuotes(sub.Description) + "'"
+			}
+			aliasLine += "\n"
+			b.WriteString(aliasLine)
+		}
+		nextPath := appendPath(path, sub.Name)
+		writeFishEntries(sub, b, command, nextPath)
+	}
+}
+
+// fishConditionForFlags returns the fish condition needed to scope flag suggestions to the
+// current subcommand path while leaving root flags globally available.
+func fishConditionForFlags(path []string) string {
+	if len(path) == 0 {
+		return ""
+	}
+	return "__fish_seen_subcommand_from " + path[len(path)-1]
+}
+
+// fishConditionForSubcommands returns the fish condition that ensures subcommand suggestions
+// appear only after their parent command token has been entered.
+func fishConditionForSubcommands(path []string) string {
+	if len(path) == 0 {
+		return "__fish_use_subcommand"
+	}
+	return "__fish_seen_subcommand_from " + path[len(path)-1]
+}
+
+// appendPath creates a new slice with the next subcommand name appended so recursive
+// completion builders can keep the traversal stack immutable.
+func appendPath(path []string, value string) []string {
+	next := make([]string, len(path)+1)
+	copy(next, path)
+	next[len(path)] = value
+	return next
+}
+
+// escapeSingleQuotes prepares text for inclusion in single-quoted shell strings so flag
+// descriptions render safely in the generated scripts.
+func escapeSingleQuotes(s string) string {
+	return strings.ReplaceAll(s, "'", "\\'")
+}
+
+// escapeDoubleQuotes prepares text for inclusion in double-quoted shell strings which is
+// required for PowerShell and Nushell emission.
+func escapeDoubleQuotes(s string) string {
+	return strings.ReplaceAll(s, "\"", "\\\"")
+}
+
+// writePowerShellEntries walks the parser tree and emits CompletionResult entries so the
+// PowerShell script can surface flags, positionals, and subcommands interactively.
+func writePowerShellEntries(sc *Subcommand, b *strings.Builder) {
+	for _, f := range sc.Flags {
+		if f.Hidden {
+			continue
+		}
+		if f.LongName != "" {
+			writePowerShellLine("--"+f.LongName, f.Description, "ParameterName", b)
+		}
+		if f.ShortName != "" {
+			writePowerShellLine("-"+f.ShortName, f.Description, "ParameterName", b)
+		}
+	}
+	for _, p := range sc.PositionalFlags {
+		if p.Hidden {
+			continue
+		}
+		if p.Name == "" {
+			continue
+		}
+		writePowerShellLine(p.Name, p.Description, "ParameterValue", b)
+	}
+	for _, sub := range sc.Subcommands {
+		if sub.Hidden {
+			continue
+		}
+		writePowerShellLine(sub.Name, sub.Description, "Command", b)
+		if sub.ShortName != "" {
+			writePowerShellLine(sub.ShortName, sub.Description, "Command", b)
+		}
+		writePowerShellEntries(sub, b)
+	}
+}
+
+// writePowerShellLine emits a single CompletionResult definition with the supplied tooltip and
+// completion type for consumption by Register-ArgumentCompleter.
+func writePowerShellLine(value, description, kind string, b *strings.Builder) {
+	tooltip := description
+	if tooltip == "" {
+		tooltip = value
+	}
+	line := fmt.Sprintf("        [System.Management.Automation.CompletionResult]::new(\"%s\", \"%s\", \"%s\", \"%s\")\n", escapeDoubleQuotes(value), escapeDoubleQuotes(value), kind, escapeDoubleQuotes(tooltip))
+	b.WriteString(line)
+}
+
+// writeNushellEntries collects all completion values into Nushell's structured format so
+// external commands can expose their interactive help inside the shell.
+func writeNushellEntries(sc *Subcommand, b *strings.Builder) {
+	for _, f := range sc.Flags {
+		if f.Hidden {
+			continue
+		}
+		if f.LongName != "" {
+			writeNushellLine("--"+f.LongName, f.Description, b)
+		}
+		if f.ShortName != "" {
+			writeNushellLine("-"+f.ShortName, f.Description, b)
+		}
+	}
+	for _, p := range sc.PositionalFlags {
+		if p.Hidden {
+			continue
+		}
+		if p.Name == "" {
+			continue
+		}
+		writeNushellLine(p.Name, p.Description, b)
+	}
+	for _, sub := range sc.Subcommands {
+		if sub.Hidden {
+			continue
+		}
+		writeNushellLine(sub.Name, sub.Description, b)
+		if sub.ShortName != "" {
+			writeNushellLine(sub.ShortName, sub.Description, b)
+		}
+		writeNushellEntries(sub, b)
+	}
+}
+
+// writeNushellLine emits a single structured completion item for Nushell with a value and
+// friendly description.
+func writeNushellLine(value, description string, b *strings.Builder) {
+	tooltip := description
+	if tooltip == "" {
+		tooltip = value
+	}
+	line := fmt.Sprintf("        { value: \"%s\", description: \"%s\" }\n", escapeDoubleQuotes(value), escapeDoubleQuotes(tooltip))
+	b.WriteString(line)
+}
+
+// writeNushellFlagSignature appends flag signature stubs so Nushell understands which
+// switches are available when invoking the external command.
+func writeNushellFlagSignature(sc *Subcommand, b *strings.Builder) {
+	for _, f := range sc.Flags {
+		if f.Hidden {
+			continue
+		}
+		if f.LongName != "" || f.ShortName != "" {
+			line := "    "
+			if f.LongName != "" {
+				line += "--" + f.LongName
+			}
+			if f.ShortName != "" {
+				if f.LongName != "" {
+					line += "(-" + f.ShortName + ")"
+				} else {
+					line += "-" + f.ShortName
+				}
+			}
+			line += "\n"
+			b.WriteString(line)
+		}
+	}
+	for _, sub := range sc.Subcommands {
+		if sub.Hidden {
+			continue
+		}
+		writeNushellFlagSignature(sub, b)
+	}
 }

--- a/completion_test.go
+++ b/completion_test.go
@@ -7,42 +7,120 @@ import (
 	"github.com/integrii/flaggy"
 )
 
-func TestGenerateBashCompletion(t *testing.T) {
-	p := flaggy.NewParser("testapp")
-	var str string
-	p.String(&str, "", "testflag", "flag for testing")
-	p.AddPositionalValue(&str, "pos", 2, false, "positional")
-	sub := flaggy.NewSubcommand("sub")
-	p.AttachSubcommand(sub, 1)
+// newCompletionParser builds a parser populated with the fictitious fleet commands used
+// to validate shell completion generators across every supported shell variant.
+func newCompletionParser() (*flaggy.Parser, []string) {
+	p := flaggy.NewParser("starfleet")
+	var route string
+	p.String(&route, "w", "warp", "Enable warp calibration during deployment")
+	p.AddPositionalValue(&route, "sector", 2, false, "Target sector coordinate")
 
-	out := flaggy.GenerateBashCompletion(p)
-	if !strings.Contains(out, "--testflag") {
-		t.Fatalf("expected flag in bash completion output: %s", out)
+	commands := []string{"deploy", "destroy", "diagnose", "dock"}
+	for _, name := range commands {
+		sub := flaggy.NewSubcommand(name)
+		sub.Description = "Handle " + name + " operations"
+		p.AttachSubcommand(sub, 1)
 	}
-	if !strings.Contains(out, "sub") {
-		t.Fatalf("expected subcommand in bash completion output: %s", out)
-	}
-	if !strings.Contains(out, "pos") {
-		t.Fatalf("expected positional in bash completion output: %s", out)
+
+	return p, commands
+}
+
+// verifyCompletionCoverage ensures that each fictitious command surfaces within the
+// produced completion output so developers can trust the generator to describe real CLIs.
+func verifyCompletionCoverage(t *testing.T, output string, commands []string, shell string) {
+	t.Helper()
+	for _, name := range commands {
+		if !strings.Contains(output, name) {
+			t.Fatalf("expected %s completion to list command %s: %s", shell, name, output)
+		}
 	}
 }
 
-func TestGenerateZshCompletion(t *testing.T) {
-	p := flaggy.NewParser("testapp")
-	var str string
-	p.String(&str, "", "testflag", "flag for testing")
-	p.AddPositionalValue(&str, "pos", 2, false, "positional")
-	sub := flaggy.NewSubcommand("sub")
-	p.AttachSubcommand(sub, 1)
+// TestGenerateBashCompletion exercises bash completions with the shared fleet commands.
+func TestGenerateBashCompletion(t *testing.T) {
+	p, commands := newCompletionParser()
+	out := flaggy.GenerateBashCompletion(p)
+	verifyCompletionCoverage(t, out, commands, "bash")
+	if !strings.Contains(out, "--warp") {
+		t.Fatalf("expected bash completion to include long flag name: %s", out)
+	}
+	if !strings.Contains(out, "-w") {
+		t.Fatalf("expected bash completion to include short flag name: %s", out)
+	}
+	if !strings.Contains(out, "sector") {
+		t.Fatalf("expected bash completion to include positional name: %s", out)
+	}
+}
 
+// TestGenerateZshCompletion exercises zsh completions with the shared fleet commands.
+func TestGenerateZshCompletion(t *testing.T) {
+	p, commands := newCompletionParser()
 	out := flaggy.GenerateZshCompletion(p)
-	if !strings.Contains(out, "--testflag") {
-		t.Fatalf("expected flag in zsh completion output: %s", out)
+	verifyCompletionCoverage(t, out, commands, "zsh")
+	if !strings.Contains(out, "--warp") {
+		t.Fatalf("expected zsh completion to include long flag name: %s", out)
 	}
-	if !strings.Contains(out, "sub") {
-		t.Fatalf("expected subcommand in zsh completion output: %s", out)
+	if !strings.Contains(out, "-w") {
+		t.Fatalf("expected zsh completion to include short flag name: %s", out)
 	}
-	if !strings.Contains(out, "pos") {
-		t.Fatalf("expected positional in zsh completion output: %s", out)
+	if !strings.Contains(out, "sector") {
+		t.Fatalf("expected zsh completion to include positional name: %s", out)
+	}
+}
+
+// TestGenerateFishCompletion exercises fish completions with the shared fleet commands.
+func TestGenerateFishCompletion(t *testing.T) {
+	p, commands := newCompletionParser()
+	out := flaggy.GenerateFishCompletion(p)
+	verifyCompletionCoverage(t, out, commands, "fish")
+	if !strings.Contains(out, "complete -c starfleet") {
+		t.Fatalf("expected fish completion to target starfleet: %s", out)
+	}
+	if !strings.Contains(out, "-l warp") {
+		t.Fatalf("expected fish completion to include long flag name: %s", out)
+	}
+	if !strings.Contains(out, "-s w") {
+		t.Fatalf("expected fish completion to include short flag name: %s", out)
+	}
+	if !strings.Contains(out, "sector") {
+		t.Fatalf("expected fish completion to include positional name: %s", out)
+	}
+}
+
+// TestGeneratePowerShellCompletion exercises PowerShell completions with fleet commands.
+func TestGeneratePowerShellCompletion(t *testing.T) {
+	p, commands := newCompletionParser()
+	out := flaggy.GeneratePowerShellCompletion(p)
+	verifyCompletionCoverage(t, out, commands, "powershell")
+	if !strings.Contains(out, "Register-ArgumentCompleter") {
+		t.Fatalf("expected powershell completion to register completer: %s", out)
+	}
+	if !strings.Contains(out, "--warp") {
+		t.Fatalf("expected powershell completion to include long flag name: %s", out)
+	}
+	if !strings.Contains(out, "-w") {
+		t.Fatalf("expected powershell completion to include short flag name: %s", out)
+	}
+	if !strings.Contains(out, "sector") {
+		t.Fatalf("expected powershell completion to include positional name: %s", out)
+	}
+}
+
+// TestGenerateNushellCompletion exercises Nushell completions with the fleet commands.
+func TestGenerateNushellCompletion(t *testing.T) {
+	p, commands := newCompletionParser()
+	out := flaggy.GenerateNushellCompletion(p)
+	verifyCompletionCoverage(t, out, commands, "nushell")
+	if !strings.Contains(out, "extern \"starfleet\"") {
+		t.Fatalf("expected nushell completion to expose extern signature: %s", out)
+	}
+	if !strings.Contains(out, "\"--warp\"") {
+		t.Fatalf("expected nushell completion to include long flag name: %s", out)
+	}
+	if !strings.Contains(out, "\"-w\"") {
+		t.Fatalf("expected nushell completion to include short flag name: %s", out)
+	}
+	if !strings.Contains(out, "\"sector\"") {
+		t.Fatalf("expected nushell completion to include positional name: %s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- add fish, PowerShell, and Nushell completion generators that traverse parser state to emit shell-specific scripts
- document the expanded completion support in the README
- expand completion tests to validate outputs for bash, zsh, fish, PowerShell, and Nushell across shared sample commands

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68e0a4f789748323892f10f75ffc6511